### PR TITLE
Refactor for Dynamic task creation

### DIFF
--- a/nuvom/task.py
+++ b/nuvom/task.py
@@ -8,88 +8,113 @@ from nuvom.registry.registry import get_task_registry
 from nuvom.job import Job
 from nuvom.queue import get_queue_backend
 
+
 class Task:
-    def __init__(self, 
-                 func, 
-                 name=None, 
-                 retries=0, 
-                 store_result=True, 
-                 timeout_secs=None,
-                 before_job: Optional[Callable[[], None]] = None, 
-                 after_job: Optional[Callable[[Any], None]] = None, 
-                 on_error: Optional[Callable[[Exception], None]] = None
-                 ):
+    """
+    Represents a task wrapper that enables delayed and mapped execution.
+    Handles registration, retries, lifecycle hooks, and result persistence.
+    """
+
+    def __init__(
+        self,
+        func: Callable,
+        *,
+        name: Optional[str] = None,
+        retries: int = 0,
+        store_result: bool = True,
+        timeout_secs: Optional[int] = None,
+        before_job: Optional[Callable[[], None]] = None,
+        after_job: Optional[Callable[[Any], None]] = None,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ):
+        functools.update_wrapper(self, func)
+
         self.func = func
         self.name = name or func.__name__
-        if self.name.startswith("test_"):
-            warnings.warn(
-                f"Task '{self.name}' may shadow pytest test function collection",
-                stacklevel=2
-            )
-        
         self.retries = retries
         self.store_result = store_result
         self.timeout_secs = timeout_secs
-        
+
         self.before_job = before_job
         self.after_job = after_job
         self.on_error = on_error
-        
-        get_task_registry().register(self.name, self.func)
+
+        # Register the task in the global registry
+        self._register()
+
+    def _register(self):
+        if self.name.startswith("test_"):
+            warnings.warn(
+                f"Task '{self.name}' may interfere with pytest collection.", stacklevel=3
+            )
+        get_task_registry().register(self.name, self)
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)
 
-    def delay(self, *args, **kwargs):
+    def delay(self, *args, **kwargs) -> Job:
         job = Job(
-            func_name=self.name, 
+            func_name=self.name,
             args=args,
-            kwargs=kwargs, 
-            retries=self.retries, 
-            store_result=self.store_result, 
+            kwargs=kwargs,
+            retries=self.retries,
+            store_result=self.store_result,
             timeout_secs=self.timeout_secs,
             before_job=self.before_job,
             after_job=self.after_job,
             on_error=self.on_error,
         )
-        queue = get_queue_backend()
-        queue.enqueue(job)
-        
-        print("Job queued ", self.name, args)
+        get_queue_backend().enqueue(job)
         return job
-    
-    def submit(self, *args, **kwargs):
+
+    def submit(self, *args, **kwargs) -> Job:
         return self.delay(*args, **kwargs)
-    
-    def map(self, arg_tuples):
-        """
-        Enqueue multiple jobs in batch using a list of argument tuples.
-        """
+
+    def map(self, arg_tuples) -> list[Job]:
         jobs = []
         for args in arg_tuples:
             if not isinstance(args, (list, tuple)):
-                raise TypeError("Each map item must be a tuple or list of arguments")
+                raise TypeError("Each map() argument must be a tuple or list.")
             jobs.append(self.delay(*args))
         return jobs
 
 
-def task(_func=None, *, name=None, retries=0, store_result=True, before_job=None, after_job=None, on_error=None):
-    def wrapper(func):
+def task(
+    _func: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
+    retries: int = 0,
+    store_result: bool = True,
+    timeout_secs: Optional[int] = None,
+    before_job: Optional[Callable[[], None]] = None,
+    after_job: Optional[Callable[[Any], None]] = None,
+    on_error: Optional[Callable[[Exception], None]] = None,
+):
+    """
+    Task decorator that wraps a function as a background-executable task.
+    Can be used with or without parameters.
+    """
+
+    def decorator(func: Callable) -> Task:
         return Task(
             func,
             name=name,
             retries=retries,
             store_result=store_result,
+            timeout_secs=timeout_secs,
             before_job=before_job,
             after_job=after_job,
-            on_error=on_error
+            on_error=on_error,
         )
 
     if _func is None:
-        return wrapper
+        return decorator
     else:
-        return wrapper(_func)
+        return decorator(_func)
 
 
-def get_task(name):
+def get_task(name: str) -> Optional[Task]:
+    """
+    Lookup a registered task by name.
+    """
     return get_task_registry().get(name)


### PR DESCRIPTION
# Key refactored features

Feature | Description | Benefit
-- | -- | --
functools.update_wrapper | Preserves function name, doc, etc. | More transparent for debugging, docs
self is the Task object | Registered into registry instead of raw func | Cleaner metadata, avoids issues with method decorators
__call__ still delegates to func | Allows direct call: mytask() | Clean dev experience
All metadata lives on the Task object | (name, retries, hooks...) | Helps introspection, debugging, advanced scheduling
Better warnings for test_ prefix | With stacklevel=3 | Traces to user code, not internal utils
Supports both @task and @task(...) | Dual mode | Smooth DX like Celery but cleaner
Type hints and comments everywhere | Yes | Maintainability and clarity