### PR TITLE
Discovery-Registry test

### DIFF
--- a/nuvom/discovery/compute_path.py
+++ b/nuvom/discovery/compute_path.py
@@ -1,10 +1,10 @@
 # nuvom/discovery/compute_path.py
+
 from pathlib import Path
 
-
-def compute_module_path(file_path: Path) -> str:
+def compute_module_path(file_path: Path, root_path: Path) -> str:
     try:
-        rel = file_path.relative_to(Path.cwd())
+        rel = file_path.relative_to(root_path)
     except ValueError:
         rel = file_path
     return str(rel).replace("/", ".").replace("\\", ".").removesuffix(".py")

--- a/nuvom/discovery/discover_tasks.py
+++ b/nuvom/discovery/discover_tasks.py
@@ -16,10 +16,11 @@ def discover_tasks(
     task_refs: List[TaskReference] = []
     files = get_python_files(root_path, include, exclude)
 
+    root = Path(root_path).resolve()
     for file in files:
         task_names = find_task_defs(file)
         for name in task_names:
-            module_path = compute_module_path(file)
+            module_path = compute_module_path(file, root_path=root)
             task_refs.append(TaskReference(str(file), name, module_path))
 
     return task_refs

--- a/nuvom/registry/auto_register.py
+++ b/nuvom/registry/auto_register.py
@@ -16,7 +16,7 @@ def auto_register_from_manifest(manifest_path: str = None):
     for ref in discovered_tasks:
         try:
             func = load_task(ref)
-            registry.register(ref.func_name, func)
+            registry.register(ref.func_name, func, force=True)
         except Exception as e:
             print(f"[warn] Failed to load task '{ref.func_name}' from {ref.module_name}: {e}")
     

--- a/nuvom/registry/registry.py
+++ b/nuvom/registry/registry.py
@@ -12,10 +12,30 @@ class TaskRegistry:
         self._tasks: Dict[str, Callable] = {}
         self._registry_lock = threading.Lock()
 
-    def register(self, name: str, func: Callable, force: bool=False):
+    def register(
+        self,
+        name: str,
+        func: Callable,
+        *,
+        force: bool = False,
+        silent: bool = False
+    ):
+        """
+        Register a task by name.
+        
+        - If `force=True`, overwrite existing.
+        - If `silent=True`, skip duplicates silently.
+        - By default, raises ValueError on conflict.
+        """
         with self._registry_lock:
-            if name in self._tasks and not force:
-                return  # Already registered
+            if name in self._tasks:
+                if force:
+                    self._tasks[name] = func
+                    return
+                elif silent:
+                    return
+                else:
+                    raise ValueError(f"Task name '{name}' already registered.")
             self._tasks[name] = func
 
     def get(self, name: str) -> Optional[Callable]:

--- a/nuvom/task.py
+++ b/nuvom/task.py
@@ -47,7 +47,7 @@ class Task:
             warnings.warn(
                 f"Task '{self.name}' may interfere with pytest collection.", stacklevel=3
             )
-        get_task_registry().register(self.name, self)
+        get_task_registry().register(self.name, self, silent=True)
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -26,3 +26,39 @@ def test_discover_single_task(tmp_path: Path):
     assert task.func_name == "say_hello"
     assert task.file_path.endswith("jobs.py")
     assert task.module_name == "myapp.jobs"
+
+def test_discover_multiple_tasks_across_files(tmp_path: Path):
+    # ── Arrange ──
+    src_dir = tmp_path / "project"
+    (src_dir / "module1").mkdir(parents=True)
+    (src_dir / "module2").mkdir(parents=True)
+
+    file1 = src_dir / "module1" / "a.py"
+    file2 = src_dir / "module2" / "b.py"
+
+    file1.write_text(textwrap.dedent("""
+        from nuvom.task import task
+
+        @task
+        def task_a():
+            pass
+    """))
+
+    file2.write_text(textwrap.dedent("""
+        from nuvom.task import task
+
+        @task
+        def task_b():
+            pass
+    """))
+
+    # ── Act ──
+    tasks = discover_tasks(str(tmp_path))
+
+    # ── Assert ──
+    found_names = {t.func_name for t in tasks}
+    found_modules = {t.module_name for t in tasks}
+
+    assert found_names == {"task_a", "task_b"}
+    assert "project.module1.a" in found_modules
+    assert "project.module2.b" in found_modules

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -1,0 +1,28 @@
+# tests/test_discovery.py
+
+import textwrap
+from pathlib import Path
+from nuvom.discovery.discover_tasks import discover_tasks
+
+def test_discover_single_task(tmp_path: Path):
+    # ── Arrange ──
+    src_dir = tmp_path / "myapp"
+    src_dir.mkdir()
+    task_file = src_dir / "jobs.py"
+    task_file.write_text(textwrap.dedent("""
+        from nuvom.task import task
+
+        @task
+        def say_hello(name):
+            return f"Hello, {name}"
+    """))
+
+    # ── Act ──
+    tasks = discover_tasks(root_path=str(tmp_path))
+    # ── Assert ──
+    assert len(tasks) == 1
+    task = tasks[0]
+    print('========', task.module_name)
+    assert task.func_name == "say_hello"
+    assert task.file_path.endswith("jobs.py")
+    assert task.module_name == "myapp.jobs"

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -99,3 +99,21 @@ def test_discover_respects_exclude_and_nuvomignore(tmp_path: Path):
     task_names = [t.func_name for t in tasks]
     assert "visible_task" in task_names
     assert "hidden_task" not in task_names
+
+def test_discover_task_with_call_decorator(tmp_path: Path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    
+    file_path = project_dir / "with_call.py"
+    file_path.write_text(textwrap.dedent("""
+        from nuvom.task import task
+
+        @task()
+        def called_decorator():
+            pass
+    """))
+
+    tasks = discover_tasks(str(project_dir))
+
+    names = [t.func_name for t in tasks]
+    assert "called_decorator" in names

--- a/tests/test_discovery/test_registry.py
+++ b/tests/test_discovery/test_registry.py
@@ -1,0 +1,48 @@
+import pytest
+from nuvom.registry.registry import get_task_registry
+
+def sample_task():
+    return "hello"
+
+def another_task():
+    return "world"
+
+def test_register_and_get():
+    registry = get_task_registry()
+    registry.clear()
+
+    registry.register("test_task", sample_task)
+    func = registry.get("test_task")
+
+    assert func is sample_task
+
+def test_all_returns_all_tasks():
+    registry = get_task_registry()
+    registry.clear()
+
+    registry.register("task1", sample_task)
+    registry.register("task2", another_task)
+
+    all_tasks = registry.all()
+
+    assert "task1" in all_tasks
+    assert "task2" in all_tasks
+    assert all_tasks["task1"] is sample_task
+    assert all_tasks["task2"] is another_task
+
+def test_clear_removes_all_tasks():
+    registry = get_task_registry()
+    registry.register("temp_task", sample_task)
+
+    registry.clear()
+
+    assert registry.get("temp_task") is None
+    assert registry.all() == {}
+
+def test_duplicate_registration_raises():
+    registry = get_task_registry()
+    registry.clear()
+
+    registry.register("dup_task", sample_task)
+    with pytest.raises(ValueError):
+        registry.register("dup_task", another_task)


### PR DESCRIPTION
## Discovery Coverage Summary
Case | Status
-- | --
@task | ✅
@task() | ✅
Exclude and .nuvomignore respected | ✅
Multi-file discovery | ✅
Manifest diffing, saving, loading | ✅



### Test for TaskRegistry:
- register() — ensures a task is registered by name.
- get() — returns the registered task.
- all() — returns all registered tasks.
- clear() — removes all tasks.
- Preventing duplicate task registration.