### PR TITLE
Auto reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ pip-wheel-metadata/
 
 # === Lock Files (optional, if you're using pip-tools or poetry) ===
 poetry.lock
-requirements.txt
 requirements-dev.txt
 
 # === project local  ===

--- a/nuvom/watcher.py
+++ b/nuvom/watcher.py
@@ -1,0 +1,29 @@
+# nuvom/watcher.py
+
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+from threading import Thread
+from pathlib import Path
+from rich import print
+
+from nuvom.discovery.manifest import ManifestManager
+from nuvom.discovery.loader import load_task
+from nuvom.registry.registry import get_task_registry
+from nuvom.registry.auto_register import auto_register_from_manifest
+
+class ManifestChangeHandler(FileSystemEventHandler):
+    """
+    Watches the Nuvom manifest file for changes and reloads tasks into the registry
+    on-the-fly during --dev mode.
+    """
+    def __init__(self, manifest_path: Path):
+        self.manifest_path = manifest_path.resolve()
+
+    def on_modified(self, event):
+        if Path(event.src_path).resolve() == self.manifest_path:
+            print("[yellow]🔁 Manifest updated — reloading tasks...[/yellow]")
+            try:
+                auto_register_from_manifest()
+                print("[green]✅ Tasks reloaded.[/green]")
+            except Exception as e:
+                print(f"[red]🔥 Reload error:[/red] {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,23 @@
+annotated-types==0.7.0
+click==8.1.8
+colorama==0.4.6
+iniconfig==2.1.0
+markdown-it-py==3.0.0
+mdurl==0.1.2
+msgpack==1.1.0
+-e git+https://github.com/nahom-zewdu/Nuvom.git@537c9d90d471e4c108f3844a8691b5590427137e#egg=nuvom
+packaging==25.0
+pathspec==0.12.1
+pluggy==1.5.0
+pydantic==2.11.4
+pydantic-settings==2.9.1
+pydantic_core==2.33.2
+Pygments==2.19.1
+pytest==8.3.5
+python-dotenv==1.1.0
+rich==14.0.0
+shellingham==1.5.4
+typer==0.15.3
+typing-inspection==0.4.0
+typing_extensions==4.13.2
+watchdog==6.0.0

--- a/tasks/execute_jobs.py
+++ b/tasks/execute_jobs.py
@@ -1,0 +1,5 @@
+# tasks/execute_jobs.py
+from tasks.jobs import add
+
+job = add.delay(2, 3)
+print(f"Job queued with ID: {job.id}")

--- a/tasks/jobs.py
+++ b/tasks/jobs.py
@@ -1,0 +1,6 @@
+# tasks/jobs.py
+from nuvom.task import task
+
+@task(retries=3, store_result=True, tags=['math'], description='add this shit')
+def add(x, y):
+    return x + y


### PR DESCRIPTION
Enable automatic task re-registration during development whenever:
manifest.json changes
- The change is detected without restarting the worker
- New/updated tasks are live-registered in the TaskRegistry
- This improves DX significantly: modify code ➝ re-scan ➝ continue working. No restarts.