### PR TITLE
Feature

### DIFF
--- a/nuvom/cli/cli.py
+++ b/nuvom/cli/cli.py
@@ -1,4 +1,4 @@
-# nuvom/cli.py
+# nuvom/cli/cli.py
 
 import typer
 import threading
@@ -10,7 +10,7 @@ from nuvom import __version__
 from nuvom.config import get_settings
 from nuvom.worker import start_worker_pool
 from nuvom.result_store import get_result, get_error
-from nuvom.cli.commands import discover_tasks, list_tasks
+from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job
 from nuvom.log import logger
 
 console = Console()
@@ -76,6 +76,7 @@ def status(job_id: str):
 
 app.add_typer(discover_tasks.discover_app, name="discover")
 app.add_typer(list_tasks.list_app, name="list")
+app.add_typer(inspect_job.inspect_app, name="inspect")
 
 def main():
     app()

--- a/nuvom/cli/cli.py
+++ b/nuvom/cli/cli.py
@@ -10,7 +10,7 @@ from nuvom import __version__
 from nuvom.config import get_settings
 from nuvom.worker import start_worker_pool
 from nuvom.result_store import get_result, get_error
-from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job
+from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job, history
 from nuvom.log import logger
 
 console = Console()
@@ -77,6 +77,7 @@ def status(job_id: str):
 app.add_typer(discover_tasks.discover_app, name="discover")
 app.add_typer(list_tasks.list_app, name="list")
 app.add_typer(inspect_job.inspect_app, name="inspect")
+app.add_typer(history.history_app, name="history")
 
 def main():
     app()

--- a/nuvom/cli/commands/history.py
+++ b/nuvom/cli/commands/history.py
@@ -1,0 +1,62 @@
+import typer
+from rich.table import Table
+from rich.console import Console
+from typing import Optional
+
+from nuvom.result_store import get_backend
+
+history_app = typer.Typer(name="history", help="Show recent jobs executed by Nuvom")
+console = Console()
+
+
+@history_app.command("recent")
+def show_recent(
+    limit: Optional[int] = typer.Option(None, help="Limit the number of results"),
+    status: Optional[str] = typer.Option(None, help="Filter by status: SUCCESS | FAILED | PENDING")
+):
+    """
+    Show recent job executions.
+    """
+    backend = get_backend()
+
+    if not hasattr(backend, "list_jobs"):
+        console.print("[red]⚠️ This backend does not support job history.[/red]")
+        raise typer.Exit(1)
+
+    jobs = backend.list_jobs()
+
+    if status:
+        status = status.upper()
+        jobs = [j for j in jobs if j.get("status") == status]
+
+    jobs = sorted(jobs, key=lambda j: j.get("created_at", 0), reverse=True)
+
+    if limit:
+        jobs = jobs[:limit]
+
+    table = Table(title="Nuvom Job History")
+    table.add_column("Job ID", style="cyan")
+    table.add_column("Status", style="bold")
+    table.add_column("Task", style="green")
+    table.add_column("result", style="green")
+    table.add_column("error", style="red")
+    table.add_column("args", style="yellow")
+    table.add_column("Created", style="dim")
+    table.add_column("Completed", style="dim")
+
+    for job in jobs:
+        table.add_row(
+            job.get("job_id", "N/A"),
+            job.get("status", "N/A"),
+            job.get("func_name", "N/A"),
+            str(job.get("result", "N/A")), #int is Not Renderable; a string or other renderable object is required
+            job.get("error", "N/A"),
+            str(job.get("args", "N/A")), #list is Not Renderable; a string or other renderable object is required
+            f"{job.get('created_at', 0)}",
+            f"{job.get('completed_at', 0)}",
+        )
+
+    if not jobs:
+        console.print("[yellow]No job history found.[/yellow]")
+    else:
+        console.print(table)

--- a/nuvom/cli/commands/inspect_job.py
+++ b/nuvom/cli/commands/inspect_job.py
@@ -1,0 +1,76 @@
+# nuvom/cli/commands/inspect_job.py
+
+import typer
+import json
+from rich.console import Console
+from rich.table import Table
+from rich.syntax import Syntax
+from typing import Optional
+
+from nuvom.result_store import get_backend
+from nuvom.log import logger
+
+inspect_app = typer.Typer(name='inspect', help="Inspect a completed job by ID. Shows full metadata (result, error, args, tracebacks, etc).")
+console = Console()
+
+@inspect_app.command("job")
+def inspect_job(
+    job_id: str,
+    format: Optional[str] = typer.Option("table", "--format", "-f", help="Output format: table, json, raw"),
+):
+    """
+    Inspect a completed job by ID. Shows full metadata (result, error, args, tracebacks, etc).
+    """
+    backend = get_backend()
+    metadata = getattr(backend, "get_full", lambda _id: None)(job_id)
+
+    if not metadata:
+        console.print(f"[bold red]❌ No metadata found for job:[/bold red] {job_id}")
+        raise typer.Exit(code=1)
+
+    if format == "json":
+        console.print_json(data=metadata)
+    elif format == "raw":
+        print(metadata)
+    elif format == "table":
+        _render_table(metadata)
+    else:
+        console.print(f"[red]Invalid format:[/red] {format}")
+        raise typer.Exit(code=1)
+
+    logger.debug("Inspected job %s with format='%s'", job_id, format)
+
+def _render_table(data: dict):
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Field", style="bold")
+    table.add_column("Value", style="")
+
+    for key in [
+        "job_id",
+        "status",
+        "args",
+        "kwargs",
+        "result",
+        "error",
+        "retries_left",
+        "attempts",
+        "created_at",
+        "completed_at"
+    ]:
+        value = data.get(key)
+        if key == "error" and value and isinstance(value, dict):
+            error_trace = value.get("traceback", "").strip()
+            if error_trace:
+                syntax = Syntax(error_trace, "python", theme="monokai", line_numbers=True)
+                console.print(table)
+                console.rule("[red]Traceback[/red]")
+                console.print(syntax)
+                return
+        elif isinstance(value, (dict, list)):
+            value = json.dumps(value, indent=2)
+        else:
+            value = str(value)
+
+        table.add_row(key, value)
+
+    console.print(table)

--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from typing import Literal
+from dotenv import load_dotenv
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -10,6 +11,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # Project root + .env path resolution
 ROOT_DIR = Path(__file__).resolve().parent.parent
 ENV_PATH = ROOT_DIR / ".env"
+
+# Load environment variables from .env file FIRST
+# This ensures os.environ is populated before PydanticSettings tries to read it
+load_dotenv(dotenv_path=ENV_PATH)
 
 class NuvomSettings(BaseSettings):
     """
@@ -23,17 +28,17 @@ class NuvomSettings(BaseSettings):
         extra="ignore",
     )
 
-    environment: Literal["dev", "prod", "test"] = Field("dev", validation_alias="ENVIRONMENT")
-    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = Field("INFO", validation_alias="LOG_LEVEL")
+    environment: Literal["dev", "prod", "test"] = "dev"
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 
-    result_backend: Literal["file", "redis", "sqlite", "memory"] = Field("file", validation_alias="RESULT_BACKEND")
-    queue_backend: Literal["file", "redis", "sqlite", "memory"] = Field("file", validation_alias="QUEUE_BACKEND")
-    serialization_backend: Literal["json", "msgpack", "pickle"] = Field("msgpack", validation_alias="SERIALIZATION_BACKEND")
+    result_backend: Literal["file", "redis", "sqlite", "memory"] = "file"
+    queue_backend: Literal["file", "redis", "sqlite", "memory"] = "file"
+    serialization_backend: Literal["json", "msgpack", "pickle"] = "msgpack"
 
-    queue_maxsize: int = Field(0, validation_alias="QUEUE_MAXSIZE")
-    max_workers: int = Field(4, validation_alias="MAX_WORKERS")
-    batch_size: int = Field(1, validation_alias="BATCH_SIZE")
-    job_timeout_secs: int = Field(60, validation_alias="JOB_TIMEOUT_SECS")
+    queue_maxsize: int = 0
+    max_workers: int = 4
+    batch_size: int = 1
+    job_timeout_secs: int = 1
 
     def summary(self) -> dict:
         """Return key configuration values as a dictionary summary."""
@@ -66,7 +71,6 @@ def get_settings(force_reload: bool = False) -> NuvomSettings:
     """
     global _settings
     if _settings is None or force_reload:
-        print(f"[debug] Loading settings from: {ENV_PATH}")
         _settings = NuvomSettings()
 
         # Setup logger immediately after settings load

--- a/nuvom/execution/job_runner.py
+++ b/nuvom/execution/job_runner.py
@@ -4,8 +4,10 @@
 JobRunner executes a single job with timeout handling, lifecycle hooks, retries, 
 and result/error persistence. Uses a thread pool for task execution isolation.
 """
+import time
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+
 from nuvom.result_store import set_result, set_error
 from nuvom.queue import get_queue_backend
 from nuvom.log import logger
@@ -65,12 +67,15 @@ class JobRunner:
 
                 if job.store_result:
                     set_result(
-                            job.id, result,
+                            job_id=job.id,
+                            func_name=job.func_name,
+                            result=result,
                             args=job.args,
                             kwargs=job.kwargs,
                             retries_left=job.retries_left,
                             attempts=job.max_retries - job.retries_left,
-                            created_at=job.created_at
+                            created_at=job.created_at,
+                            completed_at=time.time(),
                         )
 
                     logger.debug(f"[Runner-{self.worker_id}] Result stored for job '{job.func_name}'.")
@@ -111,12 +116,15 @@ class JobRunner:
         else:
             if job.store_result:
                 set_error(
-                        job.id, error,
+                        job_id=job.id,
+                        func_name=job.func_name,
+                        error=error,
                         args=job.args,
                         kwargs=job.kwargs,
                         retries_left=job.retries_left,
                         attempts=job.max_retries - job.retries_left,
-                        created_at=job.created_at
+                        created_at=job.created_at,
+                        completed_at=time.time(),
                     )
 
                 job.result = str(error)

--- a/nuvom/result_backends/base.py
+++ b/nuvom/result_backends/base.py
@@ -8,7 +8,7 @@ to store and retrieve both successful results and error messages.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, List, Dict
 
 
 class BaseResultBackend(ABC):
@@ -27,6 +27,7 @@ class BaseResultBackend(ABC):
     def set_result(
         self,
         job_id: str,
+        func_name:str,
         result: Any,
         *,
         args: Optional[tuple] = None,
@@ -68,6 +69,7 @@ class BaseResultBackend(ABC):
     def set_error(
         self,
         job_id: str,
+        func_name:str,
         error: Exception,
         *,
         args: Optional[tuple] = None,
@@ -117,3 +119,11 @@ class BaseResultBackend(ABC):
             Dict containing status, args, result/error, timestamps, etc.
         """
         pass
+    @abstractmethod
+    def list_jobs(self) -> List[Dict]:
+        """
+        Return all job metadataa.
+
+        Returns:
+            List[Dict]: All job records.
+        """

--- a/nuvom/result_backends/base.py
+++ b/nuvom/result_backends/base.py
@@ -8,6 +8,7 @@ to store and retrieve both successful results and error messages.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any, Optional
 
 
 class BaseResultBackend(ABC):
@@ -15,56 +16,104 @@ class BaseResultBackend(ABC):
     Interface for result backends used to persist job results and errors.
 
     Methods:
-        set_result(job_id, result): Persist the result of a completed job.
-        get_result(job_id): Retrieve the result for a given job ID.
-        set_error(job_id, error): Persist an error message for a failed job.
-        get_error(job_id): Retrieve the error message for a given job ID.
+        set_result: Persist result along with job metadata.
+        get_result: Retrieve deserialized result.
+        set_error: Persist error along with job metadata and traceback.
+        get_error: Retrieve error message.
+        get_full: Retrieve all metadata associated with a job.
     """
 
     @abstractmethod
-    def set_result(self, job_id: str, result: object):
+    def set_result(
+        self,
+        job_id: str,
+        result: Any,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ):
         """
-        Store the result of a completed job.
+        Store the result of a completed job with full metadata.
 
         Args:
             job_id: Unique identifier for the job.
             result: The result object to store.
+            args: The positional arguments used by the job.
+            kwargs: The keyword arguments used by the job.
+            retries_left: Number of retries remaining.
+            attempts: Number of attempts made.
+            created_at: Timestamp when job was created.
+            completed_at: Timestamp when job finished.
         """
         pass
 
     @abstractmethod
-    def get_result(self, job_id: str) -> object:
+    def get_result(self, job_id: str) -> Any:
         """
-        Retrieve the result for a completed job.
+        Retrieve only the result for a given job ID.
 
         Args:
             job_id: Unique identifier for the job.
 
         Returns:
-            The stored result object.
+            The stored result object or None.
         """
         pass
 
     @abstractmethod
-    def set_error(self, job_id: str, error: str):
+    def set_error(
+        self,
+        job_id: str,
+        error: Exception,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ):
         """
-        Store an error message for a failed job.
+        Store an error for a failed job with full metadata and traceback.
 
         Args:
             job_id: Unique identifier for the job.
-            error: Error message to store.
+            error: The error/exception to store.
+            args: Arguments used in the job.
+            kwargs: Keyword arguments used in the job.
+            retries_left: Number of retries remaining.
+            attempts: Number of attempts made.
+            created_at: Timestamp when job was created.
+            completed_at: Timestamp when job failed.
         """
         pass
 
     @abstractmethod
-    def get_error(self, job_id: str) -> str:
+    def get_error(self, job_id: str) -> Optional[str]:
         """
-        Retrieve the error message for a failed job.
+        Retrieve only the error message or traceback string.
 
         Args:
             job_id: Unique identifier for the job.
 
         Returns:
-            The stored error message.
+            Error string or None.
+        """
+        pass
+
+    @abstractmethod
+    def get_full(self, job_id: str) -> Optional[dict]:
+        """
+        Return a full dictionary of job metadata, whether success or failure.
+
+        Args:
+            job_id: Unique identifier for the job.
+
+        Returns:
+            Dict containing status, args, result/error, timestamps, etc.
         """
         pass

--- a/nuvom/result_backends/file_backend.py
+++ b/nuvom/result_backends/file_backend.py
@@ -1,13 +1,15 @@
 # nuvom/result_backends/file_backend.py
 
 """
-FileResultBackend provides a simple file-based implementation of the result backend.
+FileResultBackend provides a persistent file-based implementation of the result backend.
 
-Results are serialized and stored in a dedicated directory, with each job's result
-and error saved in separate files. Supports persistence across restarts.
+Stores job results and error metadata in serialized files using a dedicated directory.
+Persists all job metadata to `.meta` files for inspection and introspection support.
 """
 
 import os
+import traceback
+from typing import Optional, Any
 
 from nuvom.result_backends.base import BaseResultBackend
 from nuvom.serialize import serialize, deserialize
@@ -15,85 +17,115 @@ from nuvom.serialize import serialize, deserialize
 
 class FileResultBackend(BaseResultBackend):
     """
-    A file-based result backend for persisting job results and errors.
+    A file-based result backend that persists job outcomes to disk.
+
+    Stores structured metadata (status, args, tracebacks, timestamps, etc.)
+    in `.meta` files for each job. Falls back to legacy `.out` and `.err`.
 
     Attributes:
-        result_dir (str): Directory where result and error files are stored.
-
-    Methods:
-        set_result(job_id, result): Store a job's result to disk.
-        get_result(job_id): Load a job's result from disk.
-        set_error(job_id, error): Store a job's error to disk.
-        get_error(job_id): Load a job's error message from disk.
+        result_dir (str): Directory for all job result files.
     """
 
     def __init__(self):
-        """
-        Initialize the result backend and create the results directory if needed.
-        """
         self.result_dir = "job_results"
         os.makedirs(self.result_dir, exist_ok=True)
 
-    def _path(self, job_id):
-        """Construct the file path for storing the job result."""
-        return os.path.join(self.result_dir, f"{job_id}.out")
+    def _path(self, job_id, ext: str = "meta") -> str:
+        """Construct the full file path for a job's metadata file."""
+        return os.path.join(self.result_dir, f"{job_id}.{ext}")
 
-    def _err_path(self, job_id):
-        """Construct the file path for storing the job error message."""
-        return os.path.join(self.result_dir, f"{job_id}.err")
-
-    def set_result(self, job_id, result):
-        """
-        Store the serialized result of a job in a file.
-
-        Args:
-            job_id (str): Unique job identifier.
-            result (Any): Result object to serialize and store.
-        """
-        os.makedirs(self.result_dir, exist_ok=True)
+    def set_result(
+        self,
+        job_id: str,
+        result: Any,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ):
+        """Store full result metadata to a `.meta` file."""
+        data = {
+            "job_id": job_id,
+            "status": "SUCCESS",
+            "result": result,
+            "args": args or [],
+            "kwargs": kwargs or {},
+            "retries_left": retries_left,
+            "attempts": attempts,
+            "created_at": created_at,
+            "completed_at": completed_at,
+        }
         with open(self._path(job_id), "wb") as f:
-            f.write(serialize(result))
+            f.write(serialize(data))
 
-    def get_result(self, job_id):
-        """
-        Retrieve and deserialize the result for a job.
+    def get_result(self, job_id: str) -> Optional[Any]:
+        """Load only the result value from metadata or fallback `.out`."""
+        meta_path = self._path(job_id)
+        if os.path.exists(meta_path):
+            with open(meta_path, "rb") as f:
+                return deserialize(f.read()).get("result")
 
-        Args:
-            job_id (str): Unique job identifier.
+        # fallback: legacy file
+        out_path = self._path(job_id, "out")
+        if os.path.exists(out_path):
+            with open(out_path, "rb") as f:
+                return deserialize(f.read())
+        return None
 
-        Returns:
-            Any: The deserialized result, or None if not found.
-        """
-        path = self._path(job_id)
-        if not os.path.exists(path):
+    def set_error(
+        self,
+        job_id: str,
+        error: Exception,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ):
+        """Store full error metadata to a `.meta` file."""
+        tb_str = traceback.format_exc()
+        data = {
+            "job_id": job_id,
+            "status": "FAILED",
+            "error": {
+                "type": type(error).__name__,
+                "message": str(error),
+                "traceback": tb_str,
+            },
+            "args": args or [],
+            "kwargs": kwargs or {},
+            "retries_left": retries_left,
+            "attempts": attempts,
+            "created_at": created_at,
+            "completed_at": completed_at,
+        }
+
+        with open(self._path(job_id), "wb") as f:
+            f.write(serialize(data))
+
+    def get_error(self, job_id: str) -> Optional[str]:
+        """Retrieve the error message from metadata or fallback `.err` file."""
+        meta_path = self._path(job_id)
+        if os.path.exists(meta_path):
+            with open(meta_path, "rb") as f:
+                data = deserialize(f.read())
+                return data.get("error", {}).get("message")
+
+        err_path = self._path(job_id, "err")
+        if os.path.exists(err_path):
+            with open(err_path, "r") as f:
+                return f.read()
+        return None
+
+    def get_full(self, job_id: str) -> Optional[dict]:
+        """Return full job state metadata from `.meta` file if available."""
+        meta_path = self._path(job_id)
+        if not os.path.exists(meta_path):
             return None
-        with open(path, "rb") as f:
+        with open(meta_path, "rb") as f:
             return deserialize(f.read())
-
-    def set_error(self, job_id, error):
-        """
-        Store the error message of a failed job in a file.
-
-        Args:
-            job_id (str): Unique job identifier.
-            error (str): Error message to store.
-        """
-        os.makedirs(self.result_dir, exist_ok=True)
-        with open(self._err_path(job_id), "w") as f:
-            f.write(str(error))
-
-    def get_error(self, job_id):
-        """
-        Retrieve the stored error message for a failed job.
-
-        Args:
-            job_id (str): Unique job identifier.
-
-        Returns:
-            str | None: The error message, or None if not found.
-        """
-        path = self._err_path(job_id)
-        if not os.path.exists(path):
-            return None
-        with open(path, "r") as f:
-            return f.read()

--- a/nuvom/result_backends/memory_backend.py
+++ b/nuvom/result_backends/memory_backend.py
@@ -1,77 +1,94 @@
-# nuvom/backends/memory_backend.py
+# nuvom/result_backends/memory_backend.py
 
 """
 MemoryResultBackend provides an in-memory implementation of the result backend.
 
-Useful for testing and non-persistent environments. Stores serialized job results
-and error messages in dictionaries. All data is lost on process termination.
+Useful for testing and non-persistent environments. Stores full job result
+metadata in-memory, including status, return value, error details, and lifecycle info.
 """
 
+import traceback
+import time
 from nuvom.serialize import serialize, deserialize
 from nuvom.result_backends.base import BaseResultBackend
 
 
 class MemoryResultBackend(BaseResultBackend):
     """
-    In-memory result backend for storing job results and errors temporarily.
+    In-memory result backend storing detailed job result metadata.
+    Suitable for testing and non-persistent workflows.
 
-    Attributes:
-        _results (dict): Maps job_id to serialized result.
-        _errors (dict): Maps job_id to error message strings.
-
-    Methods:
-        set_result(job_id, result): Serialize and store the job result.
-        get_result(job_id): Deserialize and return stored result.
-        set_error(job_id, error): Store job error as string.
-        get_error(job_id): Return stored error string.
+    Each job record includes:
+        - status: "SUCCESS" | "FAILED"
+        - result: serialized return value
+        - error: type, message, traceback (on failure)
+        - args, kwargs: job input
+        - retries_left, attempts
+        - created_at, completed_at: timestamps
     """
 
     def __init__(self):
-        """Initialize in-memory result and error stores."""
-        self._results = {}
-        self._errors = {}
+        self._store = {}
 
-    def set_result(self, job_id, result):
+    def set_result(self, job_id, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
         """
-        Store a job's result in serialized form.
-
-        Args:
-            job_id (str): Unique identifier for the job.
-            result (Any): The result object to store.
+        Store the result of a successful job along with metadata.
         """
-        self._results[job_id] = serialize(result)
+        self._store[job_id] = {
+            "job_id": job_id,
+            "status": "SUCCESS",
+            "result": serialize(result),
+            "error": None,
+            "args": args or [],
+            "kwargs": kwargs or {},
+            "retries_left": retries_left,
+            "attempts": attempts,
+            "created_at": created_at or time.time(),
+            "completed_at": time.time()
+        }
 
     def get_result(self, job_id):
         """
-        Retrieve and deserialize a stored job result.
-
-        Args:
-            job_id (str): Unique identifier for the job.
-
-        Returns:
-            Any or None: The deserialized result, or None if not found.
+        Return the deserialized result value if available.
         """
-        raw = self._results.get(job_id)
-        return deserialize(raw) if raw else None
+        entry = self._store.get(job_id)
+        if entry and entry["status"] == "SUCCESS":
+            return deserialize(entry["result"])
+        return None
 
-    def set_error(self, job_id, error):
+    def set_error(self, job_id, error, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
         """
-        Store an error message for a failed job.
-
-        Args:
-            job_id (str): Unique identifier for the job.
-            error (str): The error message.
+        Store a failed job's error with structured traceback and metadata.
         """
-        self._errors[job_id] = str(error)
+        self._store[job_id] = {
+            "job_id": job_id,
+            "status": "FAILED",
+            "result": None,
+            "error": {
+                "type": type(error).__name__,
+                "message": str(error),
+                "traceback": traceback.format_exc()
+            },
+            "args": args or [],
+            "kwargs": kwargs or {},
+            "retries_left": retries_left,
+            "attempts": attempts,
+            "created_at": created_at or time.time(),
+            "completed_at": time.time()
+        }
 
-    def get_error(self, job_id) -> str:
+    def get_error(self, job_id):
         """
-        Retrieve the error message for a failed job.
-
-        Args:
-            job_id (str): Unique identifier for the job.
-
-        Returns:
-            str or None: The stored error message, or None if not found.
+        Return the error message of a failed job, if present.
         """
-        return self._errors.get(job_id)
+        entry = self._store.get(job_id)
+        if entry and entry["status"] == "FAILED":
+            return entry["error"]
+        return None
+
+    def get_full(self, job_id):
+        """
+        Return the full metadata dict for a job.
+        Used by `nuvom inspect`.
+        """
+        return self._store.get(job_id)

--- a/nuvom/result_store.py
+++ b/nuvom/result_store.py
@@ -40,11 +40,18 @@ def reset_backend():
     _backend = None
 
 
-def set_result(job_id, result):
+def set_result(job_id, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
     """
-    Store the result for a given job ID.
+    Store the result for a given job ID, with full metadata.
     """
-    get_backend().set_result(job_id, result)
+    get_backend().set_result(
+        job_id, result,
+        args=args,
+        kwargs=kwargs,
+        retries_left=retries_left,
+        attempts=attempts,
+        created_at=created_at
+    )
 
 
 def get_result(job_id):
@@ -54,12 +61,19 @@ def get_result(job_id):
     return get_backend().get_result(job_id)
 
 
-def set_error(job_id, error):
-    """
-    Store an error message for a given job ID.
-    """
-    get_backend().set_error(job_id, error)
 
+def set_error(job_id, error, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
+    """
+    Store an error for a given job ID, with full metadata.
+    """
+    get_backend().set_error(
+        job_id, error,
+        args=args,
+        kwargs=kwargs,
+        retries_left=retries_left,
+        attempts=attempts,
+        created_at=created_at
+    )
 
 def get_error(job_id):
     """

--- a/nuvom/result_store.py
+++ b/nuvom/result_store.py
@@ -40,17 +40,20 @@ def reset_backend():
     _backend = None
 
 
-def set_result(job_id, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
+def set_result(job_id, func_name, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None, completed_at=None):
     """
     Store the result for a given job ID, with full metadata.
     """
     get_backend().set_result(
-        job_id, result,
+        job_id=job_id, 
+        func_name=func_name,
+        result=result,
         args=args,
         kwargs=kwargs,
         retries_left=retries_left,
         attempts=attempts,
-        created_at=created_at
+        created_at=created_at,
+        completed_at=completed_at,
     )
 
 
@@ -62,17 +65,20 @@ def get_result(job_id):
 
 
 
-def set_error(job_id, error, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None):
+def set_error(job_id, func_name, error, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None, completed_at=None):
     """
     Store an error for a given job ID, with full metadata.
     """
     get_backend().set_error(
-        job_id, error,
+        job_id=job_id,
+        func_name=func_name,
+        error=error,
         args=args,
         kwargs=kwargs,
         retries_left=retries_left,
         attempts=attempts,
-        created_at=created_at
+        created_at=created_at,
+        completed_at=completed_at
     )
 
 def get_error(job_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,10 @@ authors = [
 
 dependencies = [
   "rich>=13.0.0",
+  "pydantic-settings>=2.9.1",
   "pydantic>=2.0.0",
-  "typer>=0.7.0"
+  "typer>=0.7.0",
+  "python-dotenv>=1.1.0",
 ]
 
 [build-system]

--- a/tasks/execute_jobs.py
+++ b/tasks/execute_jobs.py
@@ -2,4 +2,5 @@
 from tasks.jobs import add
 
 jobs = add.map([(2, 3), (3,3), (4,4), (5,5), (6,11), (2, 11), (3,11), (4,11), (5,11), (6,11)])
-print(f"Job queued with ID: {jobs}")
+for job in jobs:
+    print(f"Job queued with ID: {job.id }")

--- a/tests/test_cli/test_cli_status.py
+++ b/tests/test_cli/test_cli_status.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 def test_status_success():
     job_id = "job-success"
     result = {"data": 123}
-    set_result(job_id, result)
+    set_result(job_id, 'test', result)
     
     result = runner.invoke(app, ["status", job_id])
     assert result.exit_code == 0
@@ -18,7 +18,7 @@ def test_status_success():
 
 def test_status_failure():
     job_id = "job-fail"
-    set_error(job_id, "Something broke")
+    set_error(job_id, 'test', "Something broke")
     
     result = runner.invoke(app, ["status", job_id])
     assert result.exit_code == 0

--- a/tests/test_cli/test_cli_status.py
+++ b/tests/test_cli/test_cli_status.py
@@ -1,4 +1,4 @@
-# tests/test_cli_status.py
+# tests/test_cli/test_cli_status.py
 
 import pytest
 from typer.testing import CliRunner

--- a/tests/test_cli/test_inspect.py
+++ b/tests/test_cli/test_inspect.py
@@ -12,7 +12,7 @@ def clear_backend():
     reset_backend()
 
 def test_inspect_command_runs_and_outputs_table():
-    set_result("job-inspect-test", 100, args=[1], kwargs={"a": 2}, created_at="2024-01-01", attempts=1)
+    set_result("job-inspect-test", 'test', 100, args=[1], kwargs={"a": 2}, created_at="2024-01-01", attempts=1)
     result = runner.invoke(app, ["inspect", "job", "job-inspect-test"])
     assert result.exit_code == 0
     assert "job-inspect-test" in result.stdout

--- a/tests/test_cli/test_inspect.py
+++ b/tests/test_cli/test_inspect.py
@@ -1,0 +1,19 @@
+import pytest
+from typer.testing import CliRunner
+from nuvom.cli.cli import app
+from nuvom.result_store import set_result, reset_backend
+
+runner = CliRunner()
+
+@pytest.fixture(autouse=True)
+def clear_backend():
+    reset_backend()
+    yield
+    reset_backend()
+
+def test_inspect_command_runs_and_outputs_table():
+    set_result("job-inspect-test", 100, args=[1], kwargs={"a": 2}, created_at="2024-01-01", attempts=1)
+    result = runner.invoke(app, ["inspect", "job", "job-inspect-test"])
+    assert result.exit_code == 0
+    assert "job-inspect-test" in result.stdout
+    assert "100" in result.stdout

--- a/tests/test_result_file_backend.py
+++ b/tests/test_result_file_backend.py
@@ -22,7 +22,7 @@ def backend():
 def test_success_result_metadata(backend):
     job_id = "file-success"
     result = [1, 2, 3]
-    backend.set_result(job_id, result, args=(1,), kwargs={"k": 1}, retries_left=1, attempts=1)
+    backend.set_result(job_id, 'test', result, args=(1,), kwargs={"k": 1}, retries_left=1, attempts=1)
 
     assert backend.get_result(job_id) == result
     assert backend.get_error(job_id) is None
@@ -38,7 +38,7 @@ def test_error_metadata(backend):
     try:
         raise ValueError("disk gone")
     except Exception as e:
-        backend.set_error(job_id, e, args=(4,), kwargs={}, retries_left=0, attempts=1)
+        backend.set_error(job_id, 'test', e, args=(4,), kwargs={}, retries_left=0, attempts=1)
 
     assert backend.get_result(job_id) is None
     assert "disk gone" in backend.get_error(job_id)

--- a/tests/test_result_file_backend.py
+++ b/tests/test_result_file_backend.py
@@ -8,31 +8,51 @@ from nuvom.result_backends.file_backend import FileResultBackend
 
 @pytest.fixture
 def backend():
-    # Set up a clean directory before each test
+    # Use a temp directory for test isolation
     test_dir = "job_results"
     if os.path.exists(test_dir):
         shutil.rmtree(test_dir)
     os.makedirs(test_dir)
-
+    
     yield FileResultBackend()
-
-    # Cleanup
+    
     shutil.rmtree(test_dir)
 
-def test_set_and_get_result(backend):
-    job_id = "job-1"
-    data = {"value": 42}
-    backend.set_result(job_id, data)
-    assert backend.get_result(job_id) == data
 
-def test_set_and_get_error(backend):
-    job_id = "err-1"
-    error = "Failure reason"
-    backend.set_error(job_id, error)
-    assert backend.get_error(job_id) == error
+def test_success_result_metadata(backend):
+    job_id = "file-success"
+    result = [1, 2, 3]
+    backend.set_result(job_id, result, args=(1,), kwargs={"k": 1}, retries_left=1, attempts=1)
+
+    assert backend.get_result(job_id) == result
+    assert backend.get_error(job_id) is None
+
+    full = backend.get_full(job_id)
+    assert full["status"] == "SUCCESS"
+    assert full["result"] == result
+    assert full.get('error', None) is None
+
+
+def test_error_metadata(backend):
+    job_id = "file-failed"
+    try:
+        raise ValueError("disk gone")
+    except Exception as e:
+        backend.set_error(job_id, e, args=(4,), kwargs={}, retries_left=0, attempts=1)
+
+    assert backend.get_result(job_id) is None
+    assert "disk gone" in backend.get_error(job_id)
+
+    full = backend.get_full(job_id)
+    assert full["status"] == "FAILED"
+    assert full["error"]["type"] == "ValueError"
+    assert full.get('result', None) is None
+    
+
 
 def test_missing_result_returns_none(backend):
     assert backend.get_result("non-existent") is None
+
 
 def test_missing_error_returns_none(backend):
     assert backend.get_error("non-existent") is None

--- a/tests/test_result_memory_backend.py
+++ b/tests/test_result_memory_backend.py
@@ -7,20 +7,41 @@ from nuvom.result_backends.memory_backend import MemoryResultBackend
 def backend():
     return MemoryResultBackend()
 
-def test_set_and_get_result(backend):
-    job_id = "job-1"
-    data = {"foo": "bar"}
-    backend.set_result(job_id, data)
-    assert backend.get_result(job_id) == data
+def test_success_result_metadata(backend):
+    job_id = "job-success"
+    result = {"data": 123}
+    backend.set_result(job_id, result, args=[1], kwargs={"x": 2}, retries_left=2, attempts=1)
 
-def test_set_and_get_error(backend):
-    job_id = "job-err"
-    error_msg = "Something went wrong"
-    backend.set_error(job_id, error_msg)
-    assert backend.get_error(job_id) == error_msg
+    assert backend.get_result(job_id) == result
+    assert backend.get_error(job_id) is None
+
+    full = backend.get_full(job_id)
+    assert full["status"] == "SUCCESS"
+    assert full["result"] is not None
+    assert full["error"] is None
+
+
+def test_error_metadata(backend):
+    job_id = "job-failed"
+    try:
+        raise ValueError("boom")
+    except ValueError as e:
+        backend.set_error(job_id, e, args=[], kwargs={}, retries_left=0, attempts=1)
+
+    assert backend.get_result(job_id) is None
+
+    error = backend.get_error(job_id)
+    assert error["type"] == "ValueError"
+    assert "boom" in error["message"]
+
+    full = backend.get_full(job_id)
+    assert full["status"] == "FAILED"
+    assert full["error"]["type"] == "ValueError"
+
 
 def test_get_result_missing(backend):
     assert backend.get_result("missing-job") is None
+
 
 def test_get_error_missing(backend):
     assert backend.get_error("missing-job") is None

--- a/tests/test_result_memory_backend.py
+++ b/tests/test_result_memory_backend.py
@@ -10,7 +10,7 @@ def backend():
 def test_success_result_metadata(backend):
     job_id = "job-success"
     result = {"data": 123}
-    backend.set_result(job_id, result, args=[1], kwargs={"x": 2}, retries_left=2, attempts=1)
+    backend.set_result(job_id, 'test', result, args=[1], kwargs={"x": 2}, retries_left=2, attempts=1)
 
     assert backend.get_result(job_id) == result
     assert backend.get_error(job_id) is None
@@ -26,7 +26,7 @@ def test_error_metadata(backend):
     try:
         raise ValueError("boom")
     except ValueError as e:
-        backend.set_error(job_id, e, args=[], kwargs={}, retries_left=0, attempts=1)
+        backend.set_error(job_id, 'test', e, args=[], kwargs={}, retries_left=0, attempts=1)
 
     assert backend.get_result(job_id) is None
 


### PR DESCRIPTION
Feature | Status | Description
-- | -- | --
inspect <job_id> | ✅ Done | View full metadata (args, status, timestamps, result/error, traceback)
Error tracebacks | ✅ Done | Captured via traceback.format_exc() and stored as structured metadata
get_full(job_id) API | ✅ Done | Added to both Memory and File result backends
CLI: nuvom inspect <job_id> | ✅ Done | Supports Rich rendering of job metadata, with fallback to JSON or raw
CLI: nuvom history recent | ✅ Done | List all job runs (status, timestamps, func name), with filters
list_jobs() API | ✅ Done | Implemented in File + Memory backends
Test coverage | ✅ Done | Verified job metadata persistence and traceability in tests
