### PR TITLE
 Add Configurable Timeout Policy to Job Execution

### DIFF
--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -41,6 +41,8 @@ class NuvomSettings(BaseSettings):
     batch_size: int = 1
     job_timeout_secs: int = 1
 
+    timeout_policy: Literal["fail", "retry", "ignore"] = "fail"
+    
     def summary(self) -> dict:
         """Return key configuration values as a dictionary summary."""
         return {
@@ -53,6 +55,7 @@ class NuvomSettings(BaseSettings):
             "queue_backend": self.queue_backend,
             "result_backend": self.result_backend,
             "serialization_backend": self.serialization_backend,
+            "timeout_policy": self.timeout_policy,
         }
 
     def display(self) -> None:

--- a/tests/test_timeout_policy.py
+++ b/tests/test_timeout_policy.py
@@ -1,0 +1,64 @@
+# tests/test_timeout_policy.py
+
+import time
+import pytest
+
+from nuvom.job import Job
+from nuvom.task import task
+from nuvom.queue import enqueue, clear
+from nuvom.result_store import get_result, get_error
+from nuvom.worker import WorkerThread, DispatcherThread
+from nuvom.config import override_settings
+from nuvom.registry.registry import get_task_registry
+
+# --- Timeout Task -----------------------------------------------------
+@task
+def sleepy():
+    time.sleep(2)
+    return "done"
+
+def _ensure_registered():
+    get_task_registry().register("sleepy", sleepy, force=True)
+
+# --- Test Setup -------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset():
+    _ensure_registered()
+    clear()
+    override_settings(
+        job_timeout_secs=1,
+        retry_delay_secs=1,
+        result_backend="memory",
+        queue_backend="memory",
+        max_workers=1,
+    )
+    yield
+    clear()
+
+def _run_job(job):
+    enqueue(job)
+    worker = WorkerThread(worker_id=0, job_timeout=1)
+    dispatcher = DispatcherThread([worker], batch_size=1, job_timeout=1)
+    worker.start(); dispatcher.start()
+    time.sleep(3)
+    worker.join(1); dispatcher.join(1)
+
+# --- Tests ------------------------------------------------------------
+
+def test_timeout_policy_fail():
+    job = Job(func_name="sleepy", retries=0, timeout_policy="fail")
+    _run_job(job)
+    assert get_result(job.id) is None
+    assert "timed out" in get_error(job.id).get('message')
+
+def test_timeout_policy_ignore():
+    job = Job(func_name="sleepy", retries=0, timeout_policy="ignore")
+    _run_job(job)
+    assert get_result(job.id) is None  # success but returns None
+    assert get_error(job.id) is None
+
+def test_timeout_policy_retry():
+    job = Job(func_name="sleepy", retries=1, retry_delay_secs=1, timeout_policy="retry")
+    _run_job(job)
+    assert get_result(job.id) is None  # retries eventually fail (task always sleeps too long)
+    assert "timed out" in get_error(job.id).get('message')


### PR DESCRIPTION
### Overview

This PR introduces a **configurable timeout policy** for task execution in Nuvom, enhancing fault tolerance and developer control over how timeout scenarios are handled. It enables each job to specify what should happen when a timeout occurs.

### ✅ Features Implemented

#### 1. **`timeout_policy` field added to `Job`**

* New options:

  * `fail`: default; marks job as failed on timeout (previous behavior)
  * `retry`: automatically retries if retries are left
  * `ignore`: ignores timeout, proceeds as if job succeeded with `None`

#### 2. **Global default from config**

* Reads from `.env` via `NUVOM_TIMEOUT_POLICY`
* Applies when job does not explicitly define its own policy

#### 3. **Integrated with `JobRunner.run()`**

* Timeout behavior enforced at execution time
* Retry logic integrates with existing retry delay support
* Result or error is stored according to timeout outcome

#### 4. **Test Suite Added**

* Covers all three policies (`fail`, `retry`, `ignore`)
* Validates correct storage behavior and retry logic

### 🔍 Why This Matters

* In production workloads, tasks may timeout due to transient issues (network, I/O)
* Developers now have full control over how the system should respond
* Supports advanced recovery flows and fault-tolerant pipelines

---
