### PR TITLE
New Features

### DIFF
--- a/jobs/job.json
+++ b/jobs/job.json
@@ -1,0 +1,1 @@
+{ "func_name": "add", "args": [2, 3] }

--- a/nuvom/cli/cli.py
+++ b/nuvom/cli/cli.py
@@ -10,7 +10,7 @@ from nuvom import __version__
 from nuvom.config import get_settings
 from nuvom.worker import start_worker_pool
 from nuvom.result_store import get_result, get_error
-from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job, history
+from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job, history, runtestworker
 from nuvom.log import logger
 
 console = Console()
@@ -78,6 +78,7 @@ app.add_typer(discover_tasks.discover_app, name="discover")
 app.add_typer(list_tasks.list_app, name="list")
 app.add_typer(inspect_job.inspect_app, name="inspect")
 app.add_typer(history.history_app, name="history")
+app.add_typer(runtestworker.runtest_app, name="runtestworker")
 
 def main():
     app()

--- a/nuvom/cli/commands/discover_tasks.py
+++ b/nuvom/cli/commands/discover_tasks.py
@@ -1,4 +1,8 @@
 # nuvom/cli/commands/discover_tasks.py
+"""
+Scan the project directory for functions decorated with @task
+and update the manifest file.
+"""
 
 import typer
 from typing import List
@@ -7,26 +11,43 @@ from rich.table import Table
 from pathlib import Path
 
 from nuvom.discovery.discover_tasks import discover_tasks
-from nuvom.discovery.reference import TaskReference
 from nuvom.discovery.manifest import ManifestManager
+from nuvom.discovery.reference import TaskReference
 from nuvom.log import logger
 
 console = Console()
-discover_app = typer.Typer(name="discover", help="Scan project for @task definitions")
+
+discover_app = typer.Typer(
+    name="discover",
+    help=(
+        "Recursively scan for @task functions and refresh .nuvom/manifest.json\n\n"
+        "Examples:\n"
+        "  nuvom discover tasks                    # default scan\n"
+        "  nuvom discover tasks --include 'app/**' --exclude 'tests/**'\n"
+    ),
+    rich_help_panel="🌟  Core Commands",
+)
+
 
 @discover_app.command("tasks")
 def discover_tasks_cli(
     root: str = ".",
     include: List[str] = typer.Option([], help="Glob patterns to include"),
-    exclude: List[str] = typer.Option([], help="Glob patterns to exclude")
+    exclude: List[str] = typer.Option([], help="Glob patterns to exclude"),
 ):
-    """Discover @task definitions and update the manifest."""
+    """Discover @task definitions and update the manifest file."""
     root_path = Path(root).resolve()
     console.print(f"[bold]🔍 Scanning tasks in:[/bold] {root_path}")
-    logger.debug("Starting task discovery in %s with include=%s and exclude=%s", root_path, include, exclude)
+    logger.debug(
+        "Starting task discovery in %s with include=%s and exclude=%s",
+        root_path,
+        include,
+        exclude,
+    )
 
-    all_refs: List[TaskReference] = discover_tasks(root_path=root, include=include, exclude=exclude)
-    logger.info("Discovered %d task(s)", len(all_refs))
+    all_refs: List[TaskReference] = discover_tasks(
+        root_path=root, include=include, exclude=exclude
+    )
     console.print(f"[cyan]🔎 Found {len(all_refs)} task(s).[/cyan]")
 
     manager = ManifestManager()
@@ -45,9 +66,11 @@ def discover_tasks_cli(
 
     if not (diff["added"] or diff["removed"] or diff["modified"]):
         console.print("[dim]No manifest changes detected.[/dim]")
-        logger.debug("No manifest changes detected")
     else:
         console.print(table)
-        console.print("[green]✅ Manifest updated.[/green]")
-        logger.info("Manifest updated with %d additions, %d removals, %d modifications",
-                    len(diff["added"]), len(diff["removed"]), len(diff["modified"]))
+        logger.info(
+            "✅ Manifest updated with %d additions, %d removals, %d modifications",
+            len(diff["added"]),
+            len(diff["removed"]),
+            len(diff["modified"]),
+        )

--- a/nuvom/cli/commands/history.py
+++ b/nuvom/cli/commands/history.py
@@ -5,18 +5,32 @@ from typing import Optional
 
 from nuvom.result_store import get_backend
 
-history_app = typer.Typer(name="history", help="Show recent jobs executed by Nuvom")
+history_app = typer.Typer(
+    name="history",
+    help=(
+        "Show recent jobs (reads backend metadata).\n\n"
+        "Examples:\n"
+        "  nuvom history recent --limit 20\n"
+        "  nuvom history recent --status FAILED\n"
+    ),
+)
+
 console = Console()
 
 
 @history_app.command("recent")
 def show_recent(
-    limit: Optional[int] = typer.Option(None, help="Limit the number of results"),
-    status: Optional[str] = typer.Option(None, help="Filter by status: SUCCESS | FAILED | PENDING")
-):
-    """
-    Show recent job executions.
-    """
+    limit: int = typer.Option(20),
+    status: Optional[str] = typer.Option(
+        None,
+        "--status",
+        "-s",
+        help="Filter by status: SUCCESS | FAILED | PENDING",
+        case_sensitive=False,
+        ),
+    ):
+    """Pretty table of recent jobs (newest first)."""
+    
     backend = get_backend()
 
     if not hasattr(backend, "list_jobs"):

--- a/nuvom/cli/commands/inspect_job.py
+++ b/nuvom/cli/commands/inspect_job.py
@@ -1,26 +1,51 @@
 # nuvom/cli/commands/inspect_job.py
+"""
+Inspect a completed job by ID and display full metadata.
 
-import typer
+Supported output formats:
+    • table  (default)
+    • json
+    • raw
+"""
+
 import json
-from rich.console import Console
-from rich.table import Table
-from rich.syntax import Syntax
 from typing import Optional
 
-from nuvom.result_store import get_backend
-from nuvom.log import logger
-from nuvom.serialize import deserialize
+import typer
+from rich.console import Console
+from rich.syntax import Syntax
+from rich.table import Table
 
-inspect_app = typer.Typer(name='inspect', help="Inspect a completed job by ID. Shows full metadata (result, error, args, tracebacks, etc).")
+from nuvom.result_store import get_backend
+from nuvom.serialize import deserialize
+from nuvom.log import logger
+
+inspect_app = typer.Typer(
+    name="inspect",
+    help=(
+        "Inspect stored job metadata.\n\n"
+        "Examples:\n"
+        "  nuvom inspect job <id>           # table view\n\n"
+        "  nuvom inspect job <id> -f json   # machine-readable\n\n"
+        "  nuvom inspect job <id> -f raw    # raw JSON + traceback\n\n"
+        ),
+    )
+
 console = Console()
 
 @inspect_app.command("job")
 def inspect_job(
     job_id: str,
-    format: Optional[str] = typer.Option("table", "--format", "-f", help="Output format: table, json, raw"),
-):
+    format: Optional[str] = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        case_sensitive=False,
+        help="table (default) | json | raw",
+        ),
+    ):
     """
-    Inspect a completed job by ID. Shows full metadata (result, error, args, tracebacks, etc).
+    Inspect the stored metadata for a finished job.
     """
     backend = get_backend()
     metadata = getattr(backend, "get_full", lambda _id: None)(job_id)
@@ -31,10 +56,13 @@ def inspect_job(
 
     if format == "json":
         console.print_json(data=metadata)
+
     elif format == "raw":
-        print(metadata)
+        _render_raw(metadata)
+
     elif format == "table":
         _render_table(metadata)
+
     else:
         console.print(f"[red]Invalid format:[/red] {format}")
         raise typer.Exit(code=1)
@@ -42,36 +70,43 @@ def inspect_job(
     logger.debug("Inspected job %s with format='%s'", job_id, format)
 
 def _render_table(data: dict):
+    """
+    Render job metadata in a Rich table. If an error has a traceback,
+    display it as a syntax-highlighted block below the table.
+    """
     if data.get("status") == "SUCCESS" and isinstance(data.get("result"), (bytes, bytearray)):
         try:
             data["result"] = deserialize(data["result"])
-        except Exception:  # leave raw if it can’t be decoded
+        except Exception:
             pass
-        
+
     table = Table(show_header=True, header_style="bold cyan")
     table.add_column("Field", style="bold")
-    table.add_column("Value", style="")
+    table.add_column("Value")
 
     for key in [
         "job_id",
         "status",
+        "func_name",
         "args",
         "kwargs",
         "result",
         "error",
         "retries_left",
         "attempts",
+        "timeout_policy",
         "created_at",
-        "completed_at"
+        "completed_at",
     ]:
         value = data.get(key)
         if key == "error" and value and isinstance(value, dict):
+            # Show panel after table
             error_trace = value.get("traceback", "").strip()
             if error_trace:
-                syntax = Syntax(error_trace, "python", theme="monokai", line_numbers=True)
+                table.add_row("error", value.get("message", ""))
                 console.print(table)
                 console.rule("[red]Traceback[/red]")
-                console.print(syntax)
+                console.print(Syntax(error_trace, "python", theme="monokai", line_numbers=True))
                 return
         elif isinstance(value, (dict, list)):
             value = json.dumps(value, indent=2)
@@ -81,3 +116,18 @@ def _render_table(data: dict):
         table.add_row(key, value)
 
     console.print(table)
+
+def _render_raw(data: dict):
+    """
+    Raw mode:
+    1. Pretty-print complete JSON metadata.
+    2. If an error traceback exists, display it in a Rich syntax block.
+    """
+    console.rule("[bold green]Job Metadata (raw)[/bold green]")
+    console.print_json(data=data)
+
+    err = data.get("error") or {}
+    tb = (err.get("traceback") or "").strip()
+    if tb:
+        console.rule("[bold red]Traceback (raw)[/bold red]")
+        console.print(Syntax(tb, "python", theme="monokai", line_numbers=True))

--- a/nuvom/cli/commands/inspect_job.py
+++ b/nuvom/cli/commands/inspect_job.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from nuvom.result_store import get_backend
 from nuvom.log import logger
+from nuvom.serialize import deserialize
 
 inspect_app = typer.Typer(name='inspect', help="Inspect a completed job by ID. Shows full metadata (result, error, args, tracebacks, etc).")
 console = Console()
@@ -41,6 +42,12 @@ def inspect_job(
     logger.debug("Inspected job %s with format='%s'", job_id, format)
 
 def _render_table(data: dict):
+    if data.get("status") == "SUCCESS" and isinstance(data.get("result"), (bytes, bytearray)):
+        try:
+            data["result"] = deserialize(data["result"])
+        except Exception:  # leave raw if it can’t be decoded
+            pass
+        
     table = Table(show_header=True, header_style="bold cyan")
     table.add_column("Field", style="bold")
     table.add_column("Value", style="")

--- a/nuvom/cli/commands/list_tasks.py
+++ b/nuvom/cli/commands/list_tasks.py
@@ -1,4 +1,7 @@
 # nuvom/cli/commands/list_tasks.py
+"""
+List registered @task definitions and their metadata.
+"""
 
 import typer
 from rich.console import Console
@@ -9,11 +12,22 @@ from nuvom.registry.registry import get_task_registry, TaskInfo
 from nuvom.log import logger
 
 console = Console()
-list_app = typer.Typer(name="list", help="List registered @task definitions and their metadata.")
+
+list_app = typer.Typer(
+    name="list",
+    help=(
+        "List tasks discovered in the manifest and registered at runtime.\n\n"
+        "Examples:\n"
+        "  nuvom list tasks                 # table of tasks\n"
+        "  nuvom discover tasks && nuvom list tasks  # rescan then list\n"
+    ),
+    rich_help_panel="🌟  Core Commands",
+)
+
 
 @list_app.command("tasks")
 def list_tasks():
-    """List @task definitions with their metadata."""
+    """Render a table of all @task definitions with metadata columns."""
     manifest = ManifestManager()
     discovered_tasks = manifest.load()
     registry = get_task_registry()
@@ -35,8 +49,7 @@ def list_tasks():
         table.add_row(task.func_name, task.module_name, task.file_path, tags, description)
 
     if not discovered_tasks:
-        console.print("[dim]No task definitions found.[/dim]")
-        logger.info("No tasks found to list")
+        console.print("[yellow]No task definitions found.[/yellow]")
     else:
         console.print(table)
         logger.info("Listed %d tasks", len(discovered_tasks))

--- a/nuvom/cli/commands/runtestworker.py
+++ b/nuvom/cli/commands/runtestworker.py
@@ -21,8 +21,12 @@ from nuvom.log import logger
 from nuvom.registry.auto_register import auto_register_from_manifest
 
 runtest_app = typer.Typer(
-    help="Run a single job JSON deterministically (CI / local dev)"
-)
+    help=(
+        "Run a single job JSON synchronously (ideal for CI).\n\n"
+        "Example:\n"
+        "  nuvom runtestworker run ./job.json\n"
+        ),
+    )
 
 console = Console()
 
@@ -55,12 +59,12 @@ def runtestworker(
     try:
         payload = json.loads(job_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        console.print(Panel(str(exc), title="Invalid JSON", style="red"))
+        console.print(Panel(str(exc), title="Invalid JSON", style="bold red"))
         sys.exit(1)
 
     func_name: str | None = payload.get("func_name")
     if not func_name:
-        console.print(Panel("Missing 'func_name' field", style="red"))
+        console.print(Panel("Missing 'func_name' field", style="bold red"))
         sys.exit(1)
 
     # ── Optional: dynamically import the supplied task module ───────────
@@ -73,7 +77,7 @@ def runtestworker(
             logger.debug("[TestWorker] Imported task module %s", task_module)
         else:
             console.print(
-                Panel(f"Could not import task module: {task_module}", style="red")
+                Panel(f"Could not import task module: {task_module}", style="bold red")
             )
             sys.exit(1)
     else:
@@ -114,7 +118,7 @@ def runtestworker(
             Panel(
                 f"[bold red]{type(exc).__name__}[/bold red]: {exc}",
                 title="FAILED",
-                style="red",
+                style="bold red",
             )
         )
         logger.exception("TestWorker failed")

--- a/nuvom/cli/commands/runtestworker.py
+++ b/nuvom/cli/commands/runtestworker.py
@@ -1,0 +1,65 @@
+# nuvom/cli/commands/runtestworker.py
+
+"""
+Dev-only synchronous worker: execute a single job JSON payload locally.
+
+Example:
+    nuvom runtestworker ./job.json
+"""
+
+import json
+import sys
+import typer
+from pathlib import Path
+from rich.console import Console
+from rich.panel import Panel
+
+from nuvom.job import Job
+from nuvom.log import logger
+from nuvom.registry.auto_register import auto_register_from_manifest
+
+runtest_app = typer.Typer(help="Run a single job JSON deterministically (CI/dev)")
+
+console = Console()
+
+
+@runtest_app.command("run")
+def runtestworker(
+    job_file: Path = typer.Argument(..., exists=True, readable=True, help="Path to JSON file describing the job")
+):
+    """
+    Execute one job synchronously. Exit-code 0 on success, 1 on failure.
+    """
+    try:
+        payload = json.loads(job_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        console.print(Panel(str(exc), title="Invalid JSON", style="red"))
+        sys.exit(1)
+
+    # Required fields
+    func_name = payload.get("func_name")
+    if not func_name:
+        console.print(Panel("Missing 'func_name' field", style="red"))
+        sys.exit(1)
+
+    job = Job(
+        func_name=func_name,
+        args=payload.get("args", []),
+        kwargs=payload.get("kwargs", {}),
+        store_result=False,        # keep completely local
+        timeout_secs=payload.get("timeout_secs"),
+        retries=payload.get("retries", 0),
+    )
+
+    logger.info("[TestWorker] Running %s with args=%s kwargs=%s", func_name, job.args, job.kwargs)
+
+    try:
+        auto_register_from_manifest() # Register tasks
+        
+        result = job.run()
+        console.print(Panel(f"[bold green]Result:[/bold green] {result}", title="SUCCESS", style="green"))
+        sys.exit(0)
+    except Exception as exc:  # noqa: BLE001
+        console.print(Panel(f"[bold red]{type(exc).__name__}[/bold red]: {exc}", title="FAILED", style="red"))
+        logger.exception("TestWorker failed")
+        sys.exit(1)

--- a/nuvom/cli/commands/runtestworker.py
+++ b/nuvom/cli/commands/runtestworker.py
@@ -4,13 +4,15 @@
 Dev-only synchronous worker: execute a single job JSON payload locally.
 
 Example:
-    nuvom runtestworker ./job.json
+    nuvom runtestworker run ./job.json
 """
 
 import json
 import sys
-import typer
+import importlib.util
 from pathlib import Path
+
+import typer
 from rich.console import Console
 from rich.panel import Panel
 
@@ -18,48 +20,102 @@ from nuvom.job import Job
 from nuvom.log import logger
 from nuvom.registry.auto_register import auto_register_from_manifest
 
-runtest_app = typer.Typer(help="Run a single job JSON deterministically (CI/dev)")
+runtest_app = typer.Typer(
+    help="Run a single job JSON deterministically (CI / local dev)"
+)
 
 console = Console()
 
 
 @runtest_app.command("run")
 def runtestworker(
-    job_file: Path = typer.Argument(..., exists=True, readable=True, help="Path to JSON file describing the job")
-):
+    job_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        readable=True,
+        help="Path to JSON file describing the job",
+    ),
+    task_module: Path = typer.Option(
+        None,
+        "--task-module",
+        exists=True,
+        readable=True,
+        help="Optional path to a .py file containing @task-decorated functions "
+        "that should be imported before running the job",
+    ),
+) -> None:
     """
-    Execute one job synchronously. Exit-code 0 on success, 1 on failure.
+    Execute one job synchronously.
+
+    • Exit-code **0**  → success  
+    • Exit-code **1**  → failure (exception)  
     """
+
+    # ── Load JSON payload ───────────────────────────────────────────────
     try:
         payload = json.loads(job_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         console.print(Panel(str(exc), title="Invalid JSON", style="red"))
         sys.exit(1)
 
-    # Required fields
-    func_name = payload.get("func_name")
+    func_name: str | None = payload.get("func_name")
     if not func_name:
         console.print(Panel("Missing 'func_name' field", style="red"))
         sys.exit(1)
 
+    # ── Optional: dynamically import the supplied task module ───────────
+    if task_module is not None:
+        spec = importlib.util.spec_from_file_location(task_module.stem, task_module)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = mod                             # type: ignore[arg-type]
+            spec.loader.exec_module(mod)                             # type: ignore[attr-defined]
+            logger.debug("[TestWorker] Imported task module %s", task_module)
+        else:
+            console.print(
+                Panel(f"Could not import task module: {task_module}", style="red")
+            )
+            sys.exit(1)
+    else:
+        # Fallback to manifest-based auto-registration
+        auto_register_from_manifest()
+
+    # ── Build the Job object ────────────────────────────────────────────
     job = Job(
         func_name=func_name,
         args=payload.get("args", []),
         kwargs=payload.get("kwargs", {}),
-        store_result=False,        # keep completely local
+        store_result=False,  # purely local; no backend persistence
         timeout_secs=payload.get("timeout_secs"),
         retries=payload.get("retries", 0),
     )
 
-    logger.info("[TestWorker] Running %s with args=%s kwargs=%s", func_name, job.args, job.kwargs)
+    logger.info(
+        "[TestWorker] Running %s with args=%s kwargs=%s",
+        func_name,
+        job.args,
+        job.kwargs,
+    )
 
+    # ── Execute and report ──────────────────────────────────────────────
     try:
-        auto_register_from_manifest() # Register tasks
-        
         result = job.run()
-        console.print(Panel(f"[bold green]Result:[/bold green] {result}", title="SUCCESS", style="green"))
+        console.print(
+            Panel(
+                f"[bold green]Result:[/bold green] {result}",
+                title="SUCCESS",
+                style="green",
+            )
+        )
         sys.exit(0)
+
     except Exception as exc:  # noqa: BLE001
-        console.print(Panel(f"[bold red]{type(exc).__name__}[/bold red]: {exc}", title="FAILED", style="red"))
+        console.print(
+            Panel(
+                f"[bold red]{type(exc).__name__}[/bold red]: {exc}",
+                title="FAILED",
+                style="red",
+            )
+        )
         logger.exception("TestWorker failed")
         sys.exit(1)

--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -28,6 +28,7 @@ class NuvomSettings(BaseSettings):
         extra="ignore",
     )
 
+    retry_delay_secs: int = 5
     environment: Literal["dev", "prod", "test"] = "dev"
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 

--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -41,6 +41,8 @@ class NuvomSettings(BaseSettings):
     batch_size: int = 1
     job_timeout_secs: int = 1
 
+    timeout_policy: Literal["fail", "retry", "ignore"] = "fail"
+    
     def summary(self) -> dict:
         """Return key configuration values as a dictionary summary."""
         return {
@@ -53,6 +55,7 @@ class NuvomSettings(BaseSettings):
             "queue_backend": self.queue_backend,
             "result_backend": self.result_backend,
             "serialization_backend": self.serialization_backend,
+            "timeout_policy": self.timeout_policy,
         }
 
     def display(self) -> None:

--- a/nuvom/job.py
+++ b/nuvom/job.py
@@ -34,6 +34,7 @@ class Job:
                  args=None, kwargs=None, 
                  retries=0, store_result=True, 
                  timeout_secs=None, 
+                 retry_delay_secs: int | None = None, 
                  before_job: Optional[Callable[[], None]] = None, 
                  after_job: Optional[Callable[[Any], None]] = None, 
                  on_error: Optional[Callable[[Exception], None]] = None
@@ -50,6 +51,9 @@ class Job:
         self.max_retries = retries
         self.result = None
         self.error = None
+        
+        self.retry_delay_secs = retry_delay_secs
+        self.next_retry_at: float | None = None
         
         self.before_job = before_job
         self.after_job = after_job
@@ -72,6 +76,8 @@ class Job:
             "max_retries": self.max_retries,
             "result": self.result,
             "error": self.error,
+            "retry_delay_secs": self.retry_delay_secs,
+            "next_retry_at": self.next_retry_at,
             "hooks": {
                 "before_job": bool(self.before_job),
                 "after_job": bool(self.after_job),
@@ -89,6 +95,7 @@ class Job:
             timeout_secs=data.get("timeout_secs"),
             retries=data.get("max_retries", 0),
             store_result=data.get("store_result", True),
+            retry_delay_secs=data.get("retry_delay_secs"),
         )
         job.id = data.get("id")
         job.status = data.get("status", JobStatus.PENDING)
@@ -96,6 +103,7 @@ class Job:
         job.retries_left = data.get("retries_left", job.max_retries)
         job.result = data.get("result")
         job.error = data.get("error")
+        job.next_retry_at = data.get("next_retry_at")
         return job
 
     def run(self):
@@ -110,7 +118,6 @@ class Job:
         """
         from nuvom.task import get_task
 
-        self.retries_left -= 1
         task = get_task(self.func_name)
         if not task:
             raise ValueError(f"Task '{self.func_name}' not found.")

--- a/nuvom/sdk.py
+++ b/nuvom/sdk.py
@@ -1,0 +1,42 @@
+# nuvom/sdk.py
+
+from nuvom.result_store import get_backend
+from nuvom.queue import enqueue
+from nuvom.job import Job
+
+def get_job_status(job_id: str) -> dict:
+    """
+    Return full metadata about the given job (result or error).
+    Raises KeyError if not found.
+    """
+    backend = get_backend()
+    data = backend.get_full(job_id)
+    if not data:
+        raise KeyError(f"No such job: {job_id}")
+    return data
+
+def retry_job(job_id: str) -> str | None:
+    """
+    Retry a previously failed job, if retries are allowed.
+    Returns the new job ID or None if not retryable.
+    """
+    backend = get_backend()
+    snapshot = backend.get_full(job_id)
+    if not snapshot:
+        raise KeyError(f"No such job: {job_id}")
+    
+    # Check if job is retryable
+    if snapshot["retries_left"] <= 0:
+        return None
+
+    # Create a new Job with same func/args
+    cloned = Job(
+        func_name=snapshot["func_name"],
+        args=tuple(snapshot["args"]),
+        kwargs=snapshot["kwargs"],
+        retries=snapshot["retries_left"],
+        store_result=True,
+        timeout_secs=snapshot.get("timeout_secs"),
+    )
+    enqueue(cloned)
+    return cloned.id

--- a/nuvom/worker.py
+++ b/nuvom/worker.py
@@ -79,6 +79,11 @@ class DispatcherThread(threading.Thread):
                 continue
 
             for job in jobs:
+                if job.next_retry_at and job.next_retry_at > time.time():
+                    # Not ready – push back into queue
+                    self.queue.enqueue(job)
+                    continue
+                
                 target = min(self.workers, key=lambda w: w.load())
                 target.submit(job)
                 logger.debug(f"[Dispatcher] Job {job.id} → Worker-{target.worker_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+# tests/conftest.py  (replaces the _nuvom_test_safety fixture)
+
+import pytest, threading
+from nuvom.queue import clear as clear_queue
+from nuvom.registry.registry import get_task_registry
+from nuvom.config import override_settings
+from nuvom.worker import _shutdown_event
+
+@pytest.fixture(autouse=True)
+def nuvom_isolate():
+    """
+    • Force in-memory back-ends<br>
+    • Stop stray worker threads<br>
+    • **Do NOT wipe the TaskRegistry at setup** – tasks declared with @task
+      in a test module stay registered for that test.<br>
+    • Still clean queue + registry **after** each test.
+    """
+    override_settings(queue_backend="memory", result_backend="memory")
+
+    _shutdown_event.set()
+    for t in list(threading.enumerate()):
+        if t.name.startswith(("Worker-", "Dispatcher")):
+            t.join(timeout=0.5)
+    _shutdown_event.clear()
+
+    clear_queue()                    # queue clean
+    yield                             # --- test runs here ---
+
+    # teardown: full cleanup for next test
+    _shutdown_event.set()
+    clear_queue()
+    get_task_registry().clear()

--- a/tests/test_cli/test_inspect.py
+++ b/tests/test_cli/test_inspect.py
@@ -1,3 +1,5 @@
+# tests/test_cli/test_inspect
+
 import pytest
 from typer.testing import CliRunner
 from nuvom.cli.cli import app

--- a/tests/test_cli/test_inspect_raw.py
+++ b/tests/test_cli/test_inspect_raw.py
@@ -1,0 +1,36 @@
+# tests/cli/test_inspect_raw.py
+
+import time
+from typer.testing import CliRunner
+
+from nuvom.task import task
+from nuvom.job import Job
+from nuvom.queue import enqueue, clear
+from nuvom.worker import WorkerThread, DispatcherThread
+from nuvom.cli.cli import app
+from nuvom.registry.registry import get_task_registry
+
+runner = CliRunner()
+
+@task
+def boom():
+    raise RuntimeError("kaboom")
+
+def _run_fail_job():
+    get_task_registry().register("boom", boom, force=True)
+    job = Job("boom", retries=0)
+    enqueue(job)
+    w = WorkerThread(0, job_timeout=1)
+    d = DispatcherThread([w], batch_size=1, job_timeout=1)
+    w.start(); d.start()
+    time.sleep(1.5)
+    w.join(1); d.join(1)
+    return job.id
+
+def test_inspect_raw_with_traceback():
+    clear()
+    job_id = _run_fail_job()
+    result = runner.invoke(app, ["inspect", "job", job_id, "--format", "raw"])
+    assert result.exit_code == 0
+    assert "Traceback (raw)" in result.stdout
+    assert "RuntimeError" in result.stdout

--- a/tests/test_cli/test_runtestworker.py
+++ b/tests/test_cli/test_runtestworker.py
@@ -1,0 +1,60 @@
+# tests/cli/test_runtestworker.py
+
+import json
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+from nuvom.cli.cli import app
+from nuvom.task import task
+
+runner = CliRunner()
+
+# Register a simple test task
+@task()
+def add(x, y):
+    return x + y
+
+@task()
+def fail_task():
+    raise RuntimeError("Intentional failure")
+
+
+def write_job_file(data: dict) -> Path:
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w", encoding="utf-8")
+    json.dump(data, tmp)
+    tmp.close()
+    return Path(tmp.name)
+
+
+def test_runtestworker_success():
+    job_file = write_job_file({
+        "func_name": "add",
+        "args": [2, 3]
+    })
+
+    result = runner.invoke(app, ["runtestworker", "run", str(job_file)])
+    assert result.exit_code == 0
+    assert "Result:" in result.stdout
+    assert "5" in result.stdout
+
+
+def test_runtestworker_failure():
+    job_file = write_job_file({
+        "func_name": "fail_task"
+    })
+
+    result = runner.invoke(app, ["runtestworker", "run", str(job_file)])
+    assert result.exit_code != 0
+    assert "FAILED" in result.stdout
+    assert "RuntimeError" in result.stdout
+
+
+def test_runtestworker_missing_func_name():
+    job_file = write_job_file({
+        "args": [1, 2]
+    })
+
+    result = runner.invoke(app, ["runtestworker", "run", str(job_file)])
+    assert result.exit_code != 0
+    assert "Missing 'func_name'" in result.stdout

--- a/tests/test_retry_delay.py
+++ b/tests/test_retry_delay.py
@@ -1,0 +1,81 @@
+# tests/test_retry_delay.py
+import time
+import pytest
+
+from nuvom.task import task
+from nuvom.job import Job
+from nuvom.queue import enqueue, clear
+from nuvom.worker import WorkerThread, DispatcherThread
+from nuvom.result_store import get_result
+from nuvom.config import override_settings
+from nuvom.registry.registry import get_task_registry
+
+# --- global attempt counter ------------------------------------------------
+attempt_counter = {"count": 0}
+
+@task
+def flaky_task():
+    attempt_counter["count"] += 1
+    if attempt_counter["count"] < 2:
+        raise ValueError("fail once")
+    return "recovered"
+
+
+# --- auto-reset fixture -----------------------------------------------------
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """
+    • Reset attempt counter & in-memory queue
+    • Force MEMORY queue/result back-ends for speed & isolation
+    """
+    attempt_counter["count"] = 0
+    clear()
+    override_settings(
+        retry_delay_secs=2,
+        max_workers=1,
+    )
+    yield
+    clear()
+
+
+# helper: make sure the task is in the registry for THIS process
+def _ensure_registered():
+    reg = get_task_registry()
+    reg.register("flaky_task", flaky_task, force=True)
+
+
+# --- Tests -----------------------------------------------------------------
+def test_job_is_retried_after_delay():
+    _ensure_registered()
+
+    job = Job(func_name="flaky_task", retries=1, retry_delay_secs=2)
+    enqueue(job)
+
+    worker = WorkerThread(worker_id=0, job_timeout=1)
+    dispatcher = DispatcherThread([worker], batch_size=1, job_timeout=1)
+    worker.start(); dispatcher.start()
+
+    time.sleep(0.5);  assert attempt_counter["count"] == 1  # first attempt
+    time.sleep(0.5);  assert attempt_counter["count"] == 1  # not yet retried
+    time.sleep(1);  assert attempt_counter["count"] == 2  # retried & ok
+
+    assert get_result(job.id) == "recovered"
+
+    worker.join(1); dispatcher.join(1)
+
+
+def test_job_skips_retry_if_delay_not_ready():
+    _ensure_registered()
+
+    job = Job(func_name="flaky_task", retries=1, retry_delay_secs=3)
+    enqueue(job)
+
+    worker = WorkerThread(worker_id=0, job_timeout=1)
+    dispatcher = DispatcherThread([worker], batch_size=1, job_timeout=1)
+    worker.start(); dispatcher.start()
+
+    time.sleep(2)
+    assert attempt_counter["count"] == 1          # only first attempt
+    assert get_result(job.id) is None             # no retry yet
+
+    worker.join(1); dispatcher.join(1)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,85 @@
+# tests/test_sdk.py
+
+import time
+import pytest
+
+from nuvom.task import task
+from nuvom.job import Job
+from nuvom.sdk import get_job_status, retry_job
+from nuvom.result_store import get_error
+from nuvom.queue import enqueue, clear
+from nuvom.worker import WorkerThread, DispatcherThread
+from nuvom.registry.registry import get_task_registry
+
+task_attempts = {"count": 0}
+
+@task
+def flaky():
+    task_attempts["count"] += 1
+    raise ValueError("broken")
+
+def _ensure_registered():
+    get_task_registry().register("flaky", flaky, force=True)
+
+@pytest.fixture(autouse=True)
+def reset_env():
+    task_attempts["count"] = 0
+    clear()
+    yield
+    clear()
+
+def test_get_job_status_success():
+    _ensure_registered()
+
+    job = Job("flaky", retries=0)
+    enqueue(job)
+
+    w = WorkerThread(0, job_timeout=1)
+    d = DispatcherThread([w], batch_size=1, job_timeout=1)
+    w.start(); d.start()
+    time.sleep(1.5)
+
+    meta = get_job_status(job.id)
+    assert meta["func_name"] == "flaky"
+    assert meta["status"] == "FAILED"
+    assert "error" in meta
+
+    w.join(1); d.join(1)
+
+def test_retry_job_success():
+    _ensure_registered()
+
+    job = Job("flaky", retries=1)
+    enqueue(job)
+
+    w = WorkerThread(0, job_timeout=1)
+    d = DispatcherThread([w], batch_size=1, job_timeout=1)
+    w.start(); d.start()
+    time.sleep(1.5)
+
+    new_id = retry_job(job.id)
+    assert isinstance(new_id, str)
+    assert new_id != job.id
+
+    w.join(1); d.join(1)
+
+def test_retry_job_no_more_retries():
+    _ensure_registered()
+    job = Job("flaky", retries=0)
+    enqueue(job)
+
+    w = WorkerThread(0, job_timeout=1)
+    d = DispatcherThread([w], batch_size=1, job_timeout=1)
+    w.start(); d.start()
+    time.sleep(1.5)
+
+    assert retry_job(job.id) is None
+    w.join(1); d.join(1)
+
+def test_get_job_status_invalid_id():
+    with pytest.raises(KeyError):
+        get_job_status("not-a-job")
+
+def test_retry_job_invalid_id():
+    with pytest.raises(KeyError):
+        retry_job("not-a-job")

--- a/tests/test_timeout_policy.py
+++ b/tests/test_timeout_policy.py
@@ -1,0 +1,64 @@
+# tests/test_timeout_policy.py
+
+import time
+import pytest
+
+from nuvom.job import Job
+from nuvom.task import task
+from nuvom.queue import enqueue, clear
+from nuvom.result_store import get_result, get_error
+from nuvom.worker import WorkerThread, DispatcherThread
+from nuvom.config import override_settings
+from nuvom.registry.registry import get_task_registry
+
+# --- Timeout Task -----------------------------------------------------
+@task
+def sleepy():
+    time.sleep(2)
+    return "done"
+
+def _ensure_registered():
+    get_task_registry().register("sleepy", sleepy, force=True)
+
+# --- Test Setup -------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset():
+    _ensure_registered()
+    clear()
+    override_settings(
+        job_timeout_secs=1,
+        retry_delay_secs=1,
+        result_backend="memory",
+        queue_backend="memory",
+        max_workers=1,
+    )
+    yield
+    clear()
+
+def _run_job(job):
+    enqueue(job)
+    worker = WorkerThread(worker_id=0, job_timeout=1)
+    dispatcher = DispatcherThread([worker], batch_size=1, job_timeout=1)
+    worker.start(); dispatcher.start()
+    time.sleep(3)
+    worker.join(1); dispatcher.join(1)
+
+# --- Tests ------------------------------------------------------------
+
+def test_timeout_policy_fail():
+    job = Job(func_name="sleepy", retries=0, timeout_policy="fail")
+    _run_job(job)
+    assert get_result(job.id) is None
+    assert "timed out" in get_error(job.id).get('message')
+
+def test_timeout_policy_ignore():
+    job = Job(func_name="sleepy", retries=0, timeout_policy="ignore")
+    _run_job(job)
+    assert get_result(job.id) is None  # success but returns None
+    assert get_error(job.id) is None
+
+def test_timeout_policy_retry():
+    job = Job(func_name="sleepy", retries=1, retry_delay_secs=1, timeout_policy="retry")
+    _run_job(job)
+    assert get_result(job.id) is None  # retries eventually fail (task always sleeps too long)
+    assert "timed out" in get_error(job.id).get('message')

--- a/tests/test_worker_flow.py
+++ b/tests/test_worker_flow.py
@@ -34,13 +34,10 @@ def test_smart_worker_balancing():
     reset_backend()
     _shutdown_event.clear()
 
-    q = get_queue_backend()
     registry = get_task_registry()
     registry.clear()
     registry.register("slow_add", slow_add, force=True)
     registry.register("slow_mul", slow_mul, force=True)
-
-    print("===========",registry.all())
     
     # Spawn 3 workers
     workers = []


### PR DESCRIPTION
### ✅ New Features

---

#### 🔁 **Retry Delay Support**

Jobs with retries can now specify a `retry_delay_secs` (per job or via config). This enables exponential or fixed-backoff strategies without overloading workers.

* Jobs marked for retry are **not re-executed immediately** — instead they are re-queued for later execution.
* Core scheduling logic updated in `DispatcherThread` to respect `job.next_retry_at`.

#### 🔍 **`nuvom inspect job <id>` Command**

New CLI command for inspecting full job metadata post-execution, including:

* Structured `args`, `kwargs`, result, status, retry info
* Full Python traceback (if failed)
* Output formats:

  * `table` (default): Rich table with optional traceback
  * `json`: Pretty-printed JSON
  * `raw`: Both JSON and syntax-highlighted traceback

Supports both human-readable and machine-readable modes.

#### 🧪 **`nuvom runtestworker run job.json`**

New deterministic test-runner for CI and local validation:

* Runs a single job synchronously from a JSON file
* Optional `--task-module` flag to dynamically import task definitions
* Proper exit codes for CI:

  * `0`: success
  * `1`: exception

Perfect for testing serialization, timeouts, and job side-effects locally.

---

### 📊 Observability & Debugging

#### 📜 **`nuvom history recent`**

CLI command to list recent job executions:

* Columns: job ID, status, task name, args, result/error, timestamps
* Supports `--status` and `--limit` filters
* Backend-agnostic (works with any backend that supports `list_jobs()`)

#### 🕵️ `JobRunner` Improvements

* Lifecycle hooks (`before_job`, `after_job`, `on_error`) are now isolated and logged individually
* Retries now include precise logging with countdown semantics
* Stored metadata now includes:

  * Retry count
  * Original args/kwargs
  * Creation and completion timestamps

---

### 🛠 CLI Polish

#### 🧭 Top-Level Navigation

* Rich help text for all subcommands
* `list`, `discover`, `inspect`, and `runtestworker` have structured examples, panels, and consistent UX

#### 🧾 Output Quality

* All tables now format lists/dicts into readable JSON blobs
* Tracebacks use `rich.syntax.Syntax` blocks with line numbers

---

### 🧪 Tests

* Added `test_retry_delay.py` to validate retry delay enforcement
* Integrated `pytest` fixtures for:

  * Isolated in-memory backends
  * Thread teardown safety
  * Registry consistency

---

### 🔧 Internal Refactors

* `JobRunner` refactored to clearly isolate timeout logic and error persistence
* SDK `retry_job(job_id)` now re-queues a fresh copy of the job with safe cloning
* Rich logger outputs used throughout worker/dispatcher lifecycle
