### PR TITLE
Nuvom v0.9: Plugin System, Graceful Shutdown, and SQLite Backend

### DIFF
--- a/.nuvom_plugins.toml
+++ b/.nuvom_plugins.toml
@@ -1,2 +1,2 @@
 [plugins]
-queue_backend = ["nuvom_hello_plugin.plugin:HelloPlugin"]
+result_backend = ["nuvom_hello_plugin.plugin:HelloPlugin"]

--- a/.nuvom_plugins.toml
+++ b/.nuvom_plugins.toml
@@ -1,0 +1,2 @@
+[plugins]
+queue_backend = ["nuvom_hello_plugin.plugin:HelloPlugin"]

--- a/nuvom-hello-plugin/README.md
+++ b/nuvom-hello-plugin/README.md
@@ -1,0 +1,8 @@
+# Nuvom Hello Plugin
+
+This is a demo plugin for [Nuvom](https://github.com/nahom-zewdu/Nuvom), showcasing how to write, install, and load a plugin using the official Plugin protocol.
+
+## Installation
+
+```bash
+pip install -e .

--- a/nuvom-hello-plugin/nuvom_hello_plugin/plugin.py
+++ b/nuvom-hello-plugin/nuvom_hello_plugin/plugin.py
@@ -1,0 +1,15 @@
+# nuvom-hello-plugin/nuvom_hello_plugin/plugin.py
+
+from nuvom.plugins.contracts import Plugin
+
+class HelloPlugin(Plugin):
+    api_version = "1.0"
+    name = "hello"
+    provides = ["queue_backend"]
+    requires = []
+
+    def start(self, settings: dict) -> None:
+        print("[HelloPlugin] start() called with:", settings)
+
+    def stop(self) -> None:
+        print("[HelloPlugin] stop() called")

--- a/nuvom-hello-plugin/nuvom_hello_plugin/plugin.py
+++ b/nuvom-hello-plugin/nuvom_hello_plugin/plugin.py
@@ -2,14 +2,25 @@
 
 from nuvom.plugins.contracts import Plugin
 
+
+class DummyResultBackend:
+    def set_result(self, *args, **kwargs): print("✅ Dummy result saved")
+
+    def get_result(self, job_id): return {"dummy": True, "job_id": job_id}
+
+    def set_error(self, *args, **kwargs): print("❌ Dummy error recorded")
+
+    def get_error(self, job_id): return {"error": "DummyError", "job_id": job_id}
+
+
 class HelloPlugin(Plugin):
     api_version = "1.0"
-    name = "hello"
-    provides = ["queue_backend"]
-    requires = []
+    name = "hello_plugin"
+    provides = ["result_backend"]
 
     def start(self, settings: dict) -> None:
-        print("[HelloPlugin] start() called with:", settings)
+        from nuvom.plugins.registry import register_result_backend
+        register_result_backend("dummy", DummyResultBackend)
 
     def stop(self) -> None:
-        print("[HelloPlugin] stop() called")
+        print(f"{self.provides[0]} stopped")

--- a/nuvom-hello-plugin/pyproject.toml
+++ b/nuvom-hello-plugin/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/nuvom-hello-plugin/setup.cfg
+++ b/nuvom-hello-plugin/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = nuvom-hello-plugin
+version = 0.1.0
+author = Nuvom Dev
+description = A demo plugin for Nuvom
+
+[options]
+packages = find:
+install_requires =
+    nuvom
+
+[options.entry_points]
+nuvom =
+    hello_plugin = nuvom_hello_plugin.plugin:HelloPlugin

--- a/nuvom/cli/cli.py
+++ b/nuvom/cli/cli.py
@@ -10,7 +10,7 @@ from nuvom import __version__
 from nuvom.config import get_settings
 from nuvom.worker import start_worker_pool
 from nuvom.result_store import get_result, get_error
-from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job, history, runtestworker
+from nuvom.cli.commands import discover_tasks, list_tasks, inspect_job, history, runtestworker, plugin
 from nuvom.log import logger
 
 console = Console()
@@ -103,6 +103,7 @@ app.add_typer(list_tasks.list_app,          name="list",    )
 app.add_typer(inspect_job.inspect_app,      name="inspect", )
 app.add_typer(history.history_app,          name="history", )
 app.add_typer(runtestworker.runtest_app,    name="runtestworker", rich_help_panel="⚙  Dev Tools")
+app.add_typer(plugin.plugin_app,            name="plugin",        rich_help_panel="🔌 Plugins")
 
 def main():
     app()

--- a/nuvom/cli/commands/plugin.py
+++ b/nuvom/cli/commands/plugin.py
@@ -18,7 +18,18 @@ from nuvom.plugins.loader import load_plugins
 from nuvom.plugins.registry import REGISTRY, ensure_builtins_registered
 from nuvom.plugins.contracts import Plugin, API_VERSION
 
-plugin_app = typer.Typer(help="Manage Nuvom plugins (load status, scaffold, test).")
+plugin_app = typer.Typer(
+    name="plugin",
+    help=(
+        "Manage Nuvom plugins (status, scaffold, test).\n\n"
+        "Examples:\n"
+        "  nuvom plugin status                      # Show all loaded plugins\n"
+        "  nuvom plugin scaffold my_redis_backend   # Create plugin stub\n"
+        "  nuvom plugin test nuvom_hello.plugin     # Test installed plugin\n"
+        "  nuvom plugin test ./my_plugin.py         # Test from file\n"
+    ),
+    rich_help_panel="🔌 Plugin System",
+)
 console = Console()
 
 

--- a/nuvom/cli/commands/plugin.py
+++ b/nuvom/cli/commands/plugin.py
@@ -1,0 +1,188 @@
+# nuvom/cli/commands/plugin.py
+"""
+`nuvom plugin …` – manage and inspect the plugin system.
+Currently only implements **status**; scaffold/test will be added next.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import typer
+from rich.table import Table
+from rich.console import Console
+from datetime import datetime
+import importlib.util
+import traceback
+
+from nuvom.plugins.loader import load_plugins
+from nuvom.plugins.registry import REGISTRY, ensure_builtins_registered
+from nuvom.plugins.contracts import Plugin, API_VERSION
+
+plugin_app = typer.Typer(help="Manage Nuvom plugins (load status, scaffold, test).")
+console = Console()
+
+
+@plugin_app.command("status")
+def status() -> None:
+    """
+    Display all plugins that are registered / loaded in the current process.
+    """
+    
+    ensure_builtins_registered()
+    load_plugins()                           # ensure everything is imported
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Capability")
+    table.add_column("Name")
+    table.add_column("Provider")
+    table.add_column("Loaded At")
+
+    now = datetime.now().strftime("%H:%M:%S")
+
+    for cap, bucket in REGISTRY._caps.items():               # type: ignore[attr-defined]
+        for name, obj in bucket.items():
+            provider = getattr(obj, "__class__", type(obj)).__name__
+            table.add_row(cap, name, provider, now)
+
+    if REGISTRY._caps:                                   # type: ignore[attr-defined]
+        console.print(table)
+    else:
+        console.print(table)
+        console.print("[yellow]No plugins loaded.[/yellow]")
+
+
+@plugin_app.command("scaffold")
+def scaffold(
+    name: str = typer.Argument(..., help="Short name for your plugin (e.g. my_sqs_backend)"),
+    out: Path = typer.Option(".", help="Directory to write the plugin file"),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite if file exists"),
+    capability: str = typer.Option("queue_backend", "--capability", "-c", help="Capability this plugin provides"),
+    test: bool = typer.Option(False, "--test", "-t", help="Run `plugin test` after scaffolding"),
+):
+    """
+    Scaffold a new plugin stub that implements the Plugin protocol.
+    """
+    if not name.isidentifier():
+        console.print(f"[red]❌ Invalid plugin name: {name}[/red]")
+        raise typer.Exit(code=1)
+
+    class_name = "".join(part.capitalize() for part in name.split("_"))
+    filename = out / f"{name}.py"
+
+    if filename.exists() and not force:
+        console.print(f"[yellow]⚠ File {filename} already exists. Use --force to overwrite.[/yellow]")
+        raise typer.Exit(code=1)
+
+    plugin_stub = f'''\
+
+from nuvom.plugins.contracts import Plugin
+
+class {class_name}(Plugin):
+    api_version = "1.0"
+    name = "{name}"
+    provides = ["{capability}"]      # "queue_backend", "result_backend", or other
+    requires = []                    # List dependencies this plugin needs
+
+    def start(self, settings: dict) -> None:
+        # Initialize plugin (e.g. connect to service, configure hooks)
+        pass
+
+    def stop(self) -> None:
+        # Cleanup plugin resources
+        pass
+'''
+
+    try:
+        out.mkdir(parents=True, exist_ok=True)
+        filename.write_text(plugin_stub.strip() + "\n", encoding="utf-8")
+        console.print(f"[green]✅ Plugin scaffold created:[/green] {filename}")
+    except Exception as e:
+        console.print(f"[red]❌ Failed to write file:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if test:
+        from nuvom.cli.cli import app as main_app
+        from typer.testing import CliRunner
+        console.print("[blue]Running plugin test...[/blue]")
+        result = CliRunner().invoke(main_app, ["plugin", "test", str(filename)])
+        console.print(result.output, highlight=False)
+        if result.exit_code != 0:
+            raise typer.Exit(code=1)
+
+
+
+
+@plugin_app.command("test")
+def test_plugin(
+    target: str = typer.Argument(..., help="Path to plugin .py file OR python.module path"),
+) -> None:
+    """
+    Validate a plugin and run its `start/stop` hooks.
+
+    • Works with a standalone `.py` file or an installed module path.
+    • Emits a non‑zero exit‑code on failure (good for CI).
+    """
+    from nuvom.plugins.contracts import Plugin
+
+    # ------------------------
+    # Step 1: Load the module
+    # ------------------------
+    file_path = Path(target)
+    try:
+        if file_path.exists():  # Local .py file
+            spec = importlib.util.spec_from_file_location("plugin_under_test", str(file_path))
+            if spec is None or spec.loader is None:
+                raise RuntimeError("Could not load plugin file.")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)  # type: ignore
+        else:  # Python module path
+            module = importlib.import_module(target)
+    except Exception as exc:
+        console.print(f"[red]❌ Import failed:[/red] {exc}")
+        raise typer.Exit(code=1)
+
+    # ------------------------
+    # Step 2: Find Plugin subclass
+    # ------------------------
+    plugin = None
+    for attr_name in dir(module):
+        attr = getattr(module, attr_name)
+        if isinstance(attr, type) and issubclass(attr, Plugin) and attr is not Plugin:
+            plugin = attr()
+            break
+
+    if not plugin:
+        console.print("[red]❌ No valid Plugin subclass found.[/red]")
+        raise typer.Exit(code=1)
+
+    # ------------------------
+    # Step 3: Validate metadata
+    # ------------------------
+    errors = []
+    if plugin.api_version.split(".")[0] != API_VERSION.split(".")[0]:
+        errors.append(f"API version mismatch: plugin={plugin.api_version}, core={API_VERSION}")
+    if not plugin.provides:
+        errors.append("Missing `provides`.")
+    if not callable(getattr(plugin, "start", None)):
+        errors.append("Missing or invalid `start()`.")
+    if not callable(getattr(plugin, "stop", None)):
+        errors.append("Missing or invalid `stop()`.")
+
+    if errors:
+        for err in errors:
+            console.print(f"[red]❌ {err}[/red]")
+        raise typer.Exit(code=1)
+
+    # ------------------------
+    # Step 4: Run start/stop hooks
+    # ------------------------
+    try:
+        plugin.start({})
+        plugin.stop()
+    except Exception as e:
+        console.print(f"[red]❌ start() or stop() raised exception:[/red] {e}")
+        traceback.print_exc()
+        raise typer.Exit(code=1)
+
+    # ✅ SUCCESS
+    console.print(f"[green]✅ Plugin {plugin.name} validated successfully.[/green]")

--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -1,25 +1,29 @@
 # nuvom/config.py
 
+"""
+Configuration loader (dot-env + Pydantic).
+
+Adds ``sqlite_db_path`` so the SQLite backend can be pointed anywhere from
+environment or `.env`.
+"""
+
 import os
 from pathlib import Path
 from typing import Literal
 from dotenv import load_dotenv
-
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Project root + .env path resolution
+# ------------------------------------------------------------------#
 ROOT_DIR = Path(__file__).resolve().parent.parent
 ENV_PATH = ROOT_DIR / ".env"
+load_dotenv(dotenv_path=ENV_PATH)          # Populate os.environ first
+# ------------------------------------------------------------------#
 
-# Load environment variables from .env file FIRST
-# This ensures os.environ is populated before PydanticSettings tries to read it
-load_dotenv(dotenv_path=ENV_PATH)
 
 class NuvomSettings(BaseSettings):
     """
-    Holds all environment-based configuration values for Nuvom.
-    Uses Pydantic for validation and type safety.
+    Environment-driven settings, validated and type-checked by Pydantic.
     """
 
     model_config = SettingsConfigDict(
@@ -28,6 +32,7 @@ class NuvomSettings(BaseSettings):
         extra="ignore",
     )
 
+    # ---------------- Core ----------------
     retry_delay_secs: int = 5
     environment: Literal["dev", "prod", "test"] = "dev"
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
@@ -36,15 +41,19 @@ class NuvomSettings(BaseSettings):
     queue_backend: Literal["file", "redis", "sqlite", "memory"] = "file"
     serialization_backend: Literal["json", "msgpack", "pickle"] = "msgpack"
 
+    # ---------------- Worker / Queue ----------------
     queue_maxsize: int = 0
     max_workers: int = 4
     batch_size: int = 1
     job_timeout_secs: int = 1
-
     timeout_policy: Literal["fail", "retry", "ignore"] = "fail"
-    
+
+    # ---------------- SQLite (NEW) ----------------
+    sqlite_db_path: Path = ".nuvom/nuvom.db"
+
+    # ---------------- Helpers ----------------
     def summary(self) -> dict:
-        """Return key configuration values as a dictionary summary."""
+        """Return a dict of high-level config values for quick display."""
         return {
             "env": self.environment,
             "log_level": self.log_level,
@@ -56,44 +65,37 @@ class NuvomSettings(BaseSettings):
             "result_backend": self.result_backend,
             "serialization_backend": self.serialization_backend,
             "timeout_policy": self.timeout_policy,
+            "sqlite_db": str(self.sqlite_db_path),
         }
 
     def display(self) -> None:
-        """Log the config summary to console."""
-        from nuvom.log import logger  # Delayed import to avoid circular import
+        """Pretty-print the current configuration via the central logger."""
+        from nuvom.log import logger
         logger.info("Nuvom Configuration:")
-        for key, value in self.summary().items():
-            logger.info(f"{key:20} = {value}")
+        for k, v in self.summary().items():
+            logger.info(f"{k:20} = {v}")
 
-# Internal global config state
+
+# ------------------------------------------------------------------#
 _settings: NuvomSettings | None = None
 
+
 def get_settings(force_reload: bool = False) -> NuvomSettings:
-    """
-    Get global Nuvom settings. Uses singleton pattern.
-    Use `force_reload=True` to re-read from env.
-    """
+    """Return the global settings singleton (reload if requested)."""
     global _settings
     if _settings is None or force_reload:
         _settings = NuvomSettings()
-
-        # Setup logger immediately after settings load
+        # Re-init logger with possibly new log-level
         from nuvom.log import setup_logger
         setup_logger()
-
     return _settings
 
-def override_settings(**kwargs):
-    """
-    Override settings (used in tests/dev only).
-    Raises if the key is invalid.
-    """
-    global _settings
-    if _settings is None:
-        _settings = NuvomSettings()
 
+def override_settings(**kwargs):
+    """Utility for tests to override settings on the fly."""
+    s = get_settings()
     for key, value in kwargs.items():
-        if hasattr(_settings, key):
-            setattr(_settings, key, value)
+        if hasattr(s, key):
+            setattr(s, key, value)
         else:
             raise AttributeError(f"Invalid config key: '{key}'")

--- a/nuvom/config.py
+++ b/nuvom/config.py
@@ -3,27 +3,35 @@
 """
 Configuration loader (dot-env + Pydantic).
 
-Adds ``sqlite_db_path`` so the SQLite backend can be pointed anywhere from
-environment or `.env`.
+Supports:
+• Static + plugin-defined result backends
+• SQLite database location via `sqlite_db_path`
 """
 
 import os
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Annotated
+
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # ------------------------------------------------------------------#
+# Constants & Env Loading
+# ------------------------------------------------------------------#
 ROOT_DIR = Path(__file__).resolve().parent.parent
 ENV_PATH = ROOT_DIR / ".env"
-load_dotenv(dotenv_path=ENV_PATH)          # Populate os.environ first
+load_dotenv(dotenv_path=ENV_PATH)  # Populate os.environ
+
+_BUILTIN_BACKENDS = {"file", "redis", "sqlite", "memory"}
+
 # ------------------------------------------------------------------#
-
-
+# Settings Definition
+# ------------------------------------------------------------------#
 class NuvomSettings(BaseSettings):
     """
     Environment-driven settings, validated and type-checked by Pydantic.
+    Supports plugin result/queue backends.
     """
 
     model_config = SettingsConfigDict(
@@ -32,26 +40,39 @@ class NuvomSettings(BaseSettings):
         extra="ignore",
     )
 
-    # ---------------- Core ----------------
+    # ---------- Core ----------
     retry_delay_secs: int = 5
     environment: Literal["dev", "prod", "test"] = "dev"
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 
-    result_backend: Literal["file", "redis", "sqlite", "memory"] = "file"
+    result_backend: Annotated[
+        str,
+        Field(description="Backend to store job results (built-in or plugin-defined)")
+    ] = "file"
+
     queue_backend: Literal["file", "redis", "sqlite", "memory"] = "file"
     serialization_backend: Literal["json", "msgpack", "pickle"] = "msgpack"
 
-    # ---------------- Worker / Queue ----------------
+    # ---------- Worker / Queue ----------
     queue_maxsize: int = 0
     max_workers: int = 4
     batch_size: int = 1
     job_timeout_secs: int = 1
     timeout_policy: Literal["fail", "retry", "ignore"] = "fail"
 
-    # ---------------- SQLite (NEW) ----------------
+    # ---------- SQLite ----------
     sqlite_db_path: Path = ".nuvom/nuvom.db"
 
-    # ---------------- Helpers ----------------
+    # ---------- Validator ----------
+    @field_validator("result_backend")
+    @classmethod
+    def _warn_if_plugin_backend(cls, v: str) -> str:
+        if v not in _BUILTIN_BACKENDS:
+            from nuvom.log import logger
+            logger.debug("[Config] Using plugin-defined result backend: %r", v)
+        return v
+
+    # ---------- Developer Display ----------
     def summary(self) -> dict:
         """Return a dict of high-level config values for quick display."""
         return {
@@ -77,6 +98,8 @@ class NuvomSettings(BaseSettings):
 
 
 # ------------------------------------------------------------------#
+# Singleton Access
+# ------------------------------------------------------------------#
 _settings: NuvomSettings | None = None
 
 
@@ -85,7 +108,6 @@ def get_settings(force_reload: bool = False) -> NuvomSettings:
     global _settings
     if _settings is None or force_reload:
         _settings = NuvomSettings()
-        # Re-init logger with possibly new log-level
         from nuvom.log import setup_logger
         setup_logger()
     return _settings

--- a/nuvom/plugins/contracts.py
+++ b/nuvom/plugins/contracts.py
@@ -1,0 +1,40 @@
+#  nuvom/plugins/contracts.py
+
+"""
+Plugin protocol & core version pinning.
+"""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+
+API_VERSION = "1.0"
+
+class Plugin(ABC):
+    """
+    Formal contract every third‑party plugin must implement.
+
+    Attributes
+    ----------
+    api_version : str
+        Must share major version with ``nuvom.plugins.API_VERSION``.
+    name : str
+        Unique identifier (e.g. "sqlite", "redis").
+    provides : list[str]
+        Capabilities this plugin offers (e.g. ["queue_backend"]).
+    requires : list[str]
+        Optional capabilities this plugin depends on.
+    """
+
+    api_version: str
+    name: str
+    provides: list[str]
+    requires: list[str]
+
+    # Minimal lifecycle hooks
+    @abstractmethod
+    def start(self, settings: dict) -> None:
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        ...

--- a/nuvom/plugins/loader.py
+++ b/nuvom/plugins/loader.py
@@ -1,54 +1,179 @@
 # nuvom/plugins/loader.py
 
 """
-Lightweight plugin loader.
+nuvom/plugins/loader.py
+=======================
 
-Reads `.nuvom_plugins.toml` (if present) and imports listed modules.
-Each plugin can either:
-    • expose a `register()` function
-    • perform registration at import time
+Hybrid plugin loader (back‑compatible with v0.8).
+
+• Discovers plugins from **Python entry‑points** *and* the legacy
+  `.nuvom_plugins.toml` file.
+• Accepts either a class implementing the `Plugin` protocol **or**
+  a legacy callable `register()` function (deprecation‑warned).
+• Guards against double‑loading by memoising every spec in `_LOADED`.
 """
 
+from __future__ import annotations
+
 import importlib
+import importlib.metadata as md
 import tomllib
+import warnings
 from pathlib import Path
 from types import ModuleType
-from typing import List, Sequence
+from typing import Any, Set
 
 from nuvom.log import logger
+from nuvom.plugins.contracts import API_VERSION, Plugin           # new protocol
+from nuvom.plugins.registry import REGISTRY                       # generic registry
 
-_PLUGINS_LOADED: List[str] = []
-_CONFIG_PATH = Path(".nuvom_plugins.toml")
+# --------------------------------------------------------------------------- #
+# Globals
+# --------------------------------------------------------------------------- #
+_TOML_PATH = Path(".nuvom_plugins.toml")
+_LOADED: Set[str] = set()            # memoised "module[:attr]" specs
 
 
-def _load_config() -> Sequence[str]:
-    if not _CONFIG_PATH.exists():
-        logger.debug("[Plugins] No .nuvom_plugins.toml found – skipping plugin load")
+# --------------------------------------------------------------------------- #
+# Discovery helpers
+# --------------------------------------------------------------------------- #
+def _toml_targets() -> list[str]:
+    """
+    Collect *every* dotted‑path string from `.nuvom_plugins.toml`.
+
+    Supported layouts
+    -----------------
+    Legacy:
+        [plugins]
+        modules = ["pkg.mod", "pkg.other:Class"]
+
+    Capability‑specific (preferred):
+        [plugins]
+        queue_backend   = ["pkg.q:MyQ"]
+        result_backend  = ["pkg.r:MyR"]
+        observability   = ["pkg.foo"]
+    """
+    if not _TOML_PATH.exists():
         return []
 
     try:
-        data = tomllib.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        data = tomllib.loads(_TOML_PATH.read_text("utf-8"))
     except tomllib.TOMLDecodeError as exc:
-        logger.error("[Plugins] Invalid TOML in %s: %s", _CONFIG_PATH, exc)
+        logger.error("[Plugins] Invalid TOML in %s – %s", _TOML_PATH, exc)
         return []
 
-    return list(data.get("plugins", {}).get("modules", []))
+    plugin_block = data.get("plugins", {})
+    targets: list[str] = []
+
+    # 1. legacy `[plugins].modules`
+    targets.extend(plugin_block.get("modules", []))
+
+    # 2. every other list value in `[plugins]`
+    for key, value in plugin_block.items():
+        if key == "modules":
+            continue
+        if isinstance(value, list):
+            targets.extend(value)
+
+    return targets
 
 
-def load_plugins() -> None:
+
+def _entry_point_targets() -> list[str]:
+    """Return `pkg.mod:Class` specs from the *nuvom* entry‑point group."""
+    return [ep.value for ep in md.entry_points(group="nuvom")]
+
+
+def _iter_targets():
+    """Yield every unique discovery spec (entry‑points first, then TOML)."""
+    seen: set[str] = set()
+    for spec in _entry_point_targets() + _toml_targets():
+        if spec not in seen:
+            seen.add(spec)
+            yield spec
+
+
+# --------------------------------------------------------------------------- #
+# Import helpers
+# --------------------------------------------------------------------------- #
+def _import_target(spec: str) -> Any:
     """
-    Import all plugin modules once per process. Safe to call multiple times.
+    Import `"package.module:attr"` or bare `"package.module"`.
+
+    Returns the attribute (callable/class) **or** the module object.
     """
-    if _PLUGINS_LOADED:
+    mod_path, _, attr = spec.partition(":")
+    module: ModuleType = importlib.import_module(mod_path)
+    return getattr(module, attr) if attr else module
+
+
+def _major_mismatch(core: str, plugin: str) -> bool:
+    return core.split(".", 1)[0] != plugin.split(".", 1)[0]
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+def load_plugins(settings: dict | None = None) -> None:
+    """
+    Import & register all plugins exactly once per process.
+
+    Parameters
+    ----------
+    settings :
+        Optional dict of per‑plugin configuration (passed to `plugin.start()`).
+    """
+    if _LOADED:
         return
 
-    modules = _load_config()
-    for mod_path in modules:
+    cfg = settings or {}
+
+    for spec in _iter_targets():
+        if spec in _LOADED:
+            continue
+
         try:
-            module: ModuleType = importlib.import_module(mod_path)
-            if hasattr(module, "register"):
-                module.register()
-            _PLUGINS_LOADED.append(mod_path)
-            logger.info("[Plugins] Loaded %s", mod_path)
+            target = _import_target(spec)
+
+            # ── Legacy path: callable `register()` ----------------------
+            if callable(target) and not isinstance(target, type):
+                warnings.warn(
+                    "Legacy plugin register() style is deprecated and will "
+                    "be removed in Nuvom 1.0. Implement the Plugin protocol.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                target()
+                logger.info("[Plugin‑Legacy] %s loaded", spec)
+                _LOADED.add(spec)
+                continue
+
+            # ── New path: class implementing `Plugin` -------------------
+            if isinstance(target, type) and issubclass(target, Plugin):
+                if _major_mismatch(API_VERSION, target.api_version):
+                    logger.error(
+                        "[Plugin] %s api_version %s incompatible with core %s",
+                        target.__name__, target.api_version, API_VERSION,
+                    )
+                    continue
+
+                plugin: Plugin = target()
+                plugin.start(cfg.get(plugin.name, {}))
+
+                # Register first advertised capability; plugin can register more itself
+                REGISTRY.register(plugin.provides[0], plugin.name, plugin, override=True)
+                logger.info("[Plugin] %s (%s) loaded", plugin.name, plugin.__class__.__name__)
+
+                _LOADED.add(spec)
+                continue
+
+            # ── Unknown artefact ----------------------------------------
+            logger.warning("[Plugin] %s does not expose a Plugin or register()", spec)
+
         except Exception as exc:
-            logger.exception("[Plugins] Failed to load %s: %s", mod_path, exc)
+            logger.exception("[Plugin] Failed to load %s – %s", spec, exc)
+            
+    for cap in ("queue_backend", "result_backend"):
+        for name, obj in REGISTRY._caps.get(cap, {}).items():
+            if isinstance(obj, Plugin) and obj.name not in _LOADED:
+                _LOADED.add(obj.name)

--- a/nuvom/plugins/loader.py
+++ b/nuvom/plugins/loader.py
@@ -1,0 +1,54 @@
+# nuvom/plugins/loader.py
+
+"""
+Lightweight plugin loader.
+
+Reads `.nuvom_plugins.toml` (if present) and imports listed modules.
+Each plugin can either:
+    • expose a `register()` function
+    • perform registration at import time
+"""
+
+import importlib
+import tomllib
+from pathlib import Path
+from types import ModuleType
+from typing import List, Sequence
+
+from nuvom.log import logger
+
+_PLUGINS_LOADED: List[str] = []
+_CONFIG_PATH = Path(".nuvom_plugins.toml")
+
+
+def _load_config() -> Sequence[str]:
+    if not _CONFIG_PATH.exists():
+        logger.debug("[Plugins] No .nuvom_plugins.toml found – skipping plugin load")
+        return []
+
+    try:
+        data = tomllib.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        logger.error("[Plugins] Invalid TOML in %s: %s", _CONFIG_PATH, exc)
+        return []
+
+    return list(data.get("plugins", {}).get("modules", []))
+
+
+def load_plugins() -> None:
+    """
+    Import all plugin modules once per process. Safe to call multiple times.
+    """
+    if _PLUGINS_LOADED:
+        return
+
+    modules = _load_config()
+    for mod_path in modules:
+        try:
+            module: ModuleType = importlib.import_module(mod_path)
+            if hasattr(module, "register"):
+                module.register()
+            _PLUGINS_LOADED.append(mod_path)
+            logger.info("[Plugins] Loaded %s", mod_path)
+        except Exception as exc:
+            logger.exception("[Plugins] Failed to load %s: %s", mod_path, exc)

--- a/nuvom/plugins/registry.py
+++ b/nuvom/plugins/registry.py
@@ -1,0 +1,87 @@
+# nuvom/plugins/registry.py
+
+"""
+Central registry for all Nuvom plugins.
+
+Provides:
+    • register_queue_backend()
+    • register_result_backend()
+    • get_queue_backend_cls()
+    • get_result_backend_cls()
+"""
+
+from typing import Dict, Type
+
+# --------------------------------------------------------------------------- #
+#  Internal storage
+# --------------------------------------------------------------------------- #
+_QUEUE_BACKENDS: Dict[str, Type] = {}
+_RESULT_BACKENDS: Dict[str, Type] = {}
+
+# Track if we've already registered built-ins
+_BUILTINS_REGISTERED = False
+
+
+# --------------------------------------------------------------------------- #
+#  Registration helpers
+# --------------------------------------------------------------------------- #
+def register_queue_backend(name: str, cls: Type, *, override: bool = False) -> None:
+    """
+    Register a queue backend under a short name (e.g. "sqlite", "redis").
+    """
+    _name = name.lower()
+    if _name in _QUEUE_BACKENDS and not override:
+        raise ValueError(f"Queue backend '{name}' already registered")
+    _QUEUE_BACKENDS[_name] = cls
+
+
+def register_result_backend(name: str, cls: Type, *, override: bool = False) -> None:
+    """
+    Register a result backend under a short name (e.g. "sqlite", "mongo").
+    """
+    _name = name.lower()
+    if _name in _RESULT_BACKENDS and not override:
+        raise ValueError(f"Result backend '{name}' already registered")
+    _RESULT_BACKENDS[_name] = cls
+
+
+# --------------------------------------------------------------------------- #
+#  Lazy built-in registration
+# --------------------------------------------------------------------------- #
+def _register_builtin_backends() -> None:
+    """
+    Register the built-in queue & result backends so that plugins can
+    safely override them later if desired.
+    """
+    from nuvom.queue_backends.memory_queue import MemoryJobQueue
+    from nuvom.queue_backends.file_queue import FileJobQueue
+    from nuvom.result_backends.memory_backend import MemoryResultBackend
+    from nuvom.result_backends.file_backend import FileResultBackend
+    from nuvom.result_backends.sqlite_backend import SQLiteResultBackend
+
+    register_queue_backend("memory", MemoryJobQueue, override=True)
+    register_queue_backend("file", FileJobQueue, override=True)
+
+    register_result_backend("memory", MemoryResultBackend, override=True)
+    register_result_backend("file", FileResultBackend, override=True)
+    register_result_backend("sqlite", SQLiteResultBackend, override=True)
+
+
+def _ensure_builtins_registered() -> None:
+    global _BUILTINS_REGISTERED
+    if not _BUILTINS_REGISTERED:
+        _register_builtin_backends()
+        _BUILTINS_REGISTERED = True
+
+
+# --------------------------------------------------------------------------- #
+#  Lookup helpers (guarded by lazy init)
+# --------------------------------------------------------------------------- #
+def get_queue_backend_cls(name: str):
+    _ensure_builtins_registered()
+    return _QUEUE_BACKENDS.get(name.lower())
+
+
+def get_result_backend_cls(name: str):
+    _ensure_builtins_registered()
+    return _RESULT_BACKENDS.get(name.lower())

--- a/nuvom/plugins/registry.py
+++ b/nuvom/plugins/registry.py
@@ -1,87 +1,115 @@
 # nuvom/plugins/registry.py
 
 """
-Central registry for all Nuvom plugins.
+Generic capability registry (queue_backend, result_backend, …).
 
-Provides:
-    • register_queue_backend()
-    • register_result_backend()
-    • get_queue_backend_cls()
-    • get_result_backend_cls()
+Legacy helpers remain but emit a deprecation warning.
 """
 
-from typing import Dict, Type
+from __future__ import annotations
+from collections import defaultdict
+from typing import Any, Dict
 
-# --------------------------------------------------------------------------- #
-#  Internal storage
-# --------------------------------------------------------------------------- #
-_QUEUE_BACKENDS: Dict[str, Type] = {}
-_RESULT_BACKENDS: Dict[str, Type] = {}
-
-# Track if we've already registered built-ins
-_BUILTINS_REGISTERED = False
+import warnings
 
 
-# --------------------------------------------------------------------------- #
-#  Registration helpers
-# --------------------------------------------------------------------------- #
-def register_queue_backend(name: str, cls: Type, *, override: bool = False) -> None:
-    """
-    Register a queue backend under a short name (e.g. "sqlite", "redis").
-    """
-    _name = name.lower()
-    if _name in _QUEUE_BACKENDS and not override:
-        raise ValueError(f"Queue backend '{name}' already registered")
-    _QUEUE_BACKENDS[_name] = cls
+class Registry:
+    """Internal generic registry backed by a bucket‑dict."""
+
+    def __init__(self) -> None:
+        self._caps: Dict[str, Dict[str, Any]] = defaultdict(dict)
+
+    # ----------------------------------------------------- #
+    # Public generic API
+    # ----------------------------------------------------- #
+    def register(self, cap: str, name: str, obj: Any, *, override: bool = False) -> None:
+        bucket = self._caps[cap]
+        if name in bucket and not override:
+            raise ValueError(f"{cap} provider '{name}' already registered")
+        bucket[name] = obj
+
+    def get(self, cap: str, name: str | None = None) -> Any | None:
+        ensure_builtins_registered()  
+        bucket = self._caps.get(cap, {})
+        if name is not None:
+            return bucket.get(name)
+        # If only one implementation exists, return it implicitly
+        if len(bucket) == 1:
+            return next(iter(bucket.values()))
+        
+        raise LookupError(f"Multiple {cap} providers; specify one.")
 
 
-def register_result_backend(name: str, cls: Type, *, override: bool = False) -> None:
-    """
-    Register a result backend under a short name (e.g. "sqlite", "mongo").
-    """
-    _name = name.lower()
-    if _name in _RESULT_BACKENDS and not override:
-        raise ValueError(f"Result backend '{name}' already registered")
-    _RESULT_BACKENDS[_name] = cls
+REGISTRY = Registry()
+
+# --------------------------------------------------------- #
+# Back‑compat shims (will be removed in v1.0)
+# --------------------------------------------------------- #
+def _warn_legacy(fn: str) -> None:
+    warnings.warn(
+        f"{fn} is deprecated and will be removed in Nuvom 1.0. "
+        "Implement the Plugin protocol instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
-# --------------------------------------------------------------------------- #
-#  Lazy built-in registration
-# --------------------------------------------------------------------------- #
-def _register_builtin_backends() -> None:
-    """
-    Register the built-in queue & result backends so that plugins can
-    safely override them later if desired.
-    """
+def register_queue_backend(name: str, cls: Any, *, override: bool = False) -> None:
+    _warn_legacy("register_queue_backend()")
+    REGISTRY.register("queue_backend", name.lower(), cls, override=override)
+
+
+def register_result_backend(name: str, cls: Any, *, override: bool = False) -> None:
+    _warn_legacy("register_result_backend()")
+    REGISTRY.register("result_backend", name.lower(), cls, override=override)
+
+
+def get_queue_backend_cls(name: str):
+    return REGISTRY.get("queue_backend", name.lower())
+
+
+def get_result_backend_cls(name: str):
+    return REGISTRY.get("result_backend", name.lower())
+
+
+# --------------------------------------------------------- #
+# Built‑ins (memory / file / sqlite) registered here
+# --------------------------------------------------------- #
+def _register_builtins() -> None:
     from nuvom.queue_backends.memory_queue import MemoryJobQueue
     from nuvom.queue_backends.file_queue import FileJobQueue
     from nuvom.result_backends.memory_backend import MemoryResultBackend
     from nuvom.result_backends.file_backend import FileResultBackend
     from nuvom.result_backends.sqlite_backend import SQLiteResultBackend
 
-    register_queue_backend("memory", MemoryJobQueue, override=True)
-    register_queue_backend("file", FileJobQueue, override=True)
+    REGISTRY.register("queue_backend", "memory", MemoryJobQueue, override=True)
+    REGISTRY.register("queue_backend", "file", FileJobQueue, override=True)
 
-    register_result_backend("memory", MemoryResultBackend, override=True)
-    register_result_backend("file", FileResultBackend, override=True)
-    register_result_backend("sqlite", SQLiteResultBackend, override=True)
+    REGISTRY.register("result_backend", "memory", MemoryResultBackend, override=True)
+    REGISTRY.register("result_backend", "file", FileResultBackend, override=True)
+    REGISTRY.register("result_backend", "sqlite", SQLiteResultBackend, override=True)
 
 
-def _ensure_builtins_registered() -> None:
-    global _BUILTINS_REGISTERED
-    if not _BUILTINS_REGISTERED:
-        _register_builtin_backends()
+_BUILTINS_REGISTERED = False
+_REGISTERING = False
+
+def ensure_builtins_registered() -> None:
+    global _BUILTINS_REGISTERED, _REGISTERING
+    if _BUILTINS_REGISTERED or _REGISTERING:
+        return
+    _REGISTERING = True
+    try:
+        _register_builtins()
         _BUILTINS_REGISTERED = True
+    finally:
+        _REGISTERING = False
 
 
-# --------------------------------------------------------------------------- #
-#  Lookup helpers (guarded by lazy init)
-# --------------------------------------------------------------------------- #
-def get_queue_backend_cls(name: str):
-    _ensure_builtins_registered()
-    return _QUEUE_BACKENDS.get(name.lower())
-
-
-def get_result_backend_cls(name: str):
-    _ensure_builtins_registered()
-    return _RESULT_BACKENDS.get(name.lower())
+def _reset_for_tests():
+    """
+    Clear all buckets **and** built‑in registration flags.
+    Intended for pytest fixtures only.
+    """
+    global _BUILTINS_REGISTERED
+    REGISTRY._caps.clear()
+    _BUILTINS_REGISTERED = False

--- a/nuvom/queue.py
+++ b/nuvom/queue.py
@@ -2,70 +2,80 @@
 
 """
 Queue management interface for jobs.
-Uses a configurable backend to manage job lifecycles.
+
+Delegates all persistence to a *configurable* backend class, which is resolved
+via Nuvom’s plugin registry (`nuvom.plugins.registry`).  This allows third‑party
+packages to add custom queue implementations without touching core code.
 """
+
+from __future__ import annotations
 
 from typing import List, Optional
 
 from nuvom.config import get_settings
-from nuvom.queue_backends.file_queue import FileJobQueue
-from nuvom.queue_backends.memory_queue import MemoryJobQueue
 from nuvom.job import Job
+from nuvom.plugins.registry import get_queue_backend_cls
 
+# Cached singleton instance
 _global_queue = None
 
 
+# --------------------------------------------------------------------------- #
+#  Backend resolution
+# --------------------------------------------------------------------------- #
 def get_queue_backend():
     """
-    Returns the active queue backend, initializing it if necessary.
+    Return the active queue backend (singleton).
+
+    • Uses the short name in ``NUVOM_QUEUE_BACKEND``  
+    • Looks up the concrete class from the plugin registry  
+    • Instantiates it lazily on first call
     """
     global _global_queue
     if _global_queue is not None:
         return _global_queue
 
-    backend_name = get_settings().queue_backend.lower()
+    settings = get_settings()
+    backend_name = settings.queue_backend.lower()
+    backend_cls = get_queue_backend_cls(backend_name)
 
-    if backend_name == "file":
-        _global_queue = FileJobQueue()
-    elif backend_name == "memory":
-        _global_queue = MemoryJobQueue()
-    else:
-        raise ValueError(f"Unsupported queue backend: {backend_name}")
+    if backend_cls is None:
+        raise ValueError(f"Unsupported or unregistered queue backend: {backend_name}")
 
+    _global_queue = backend_cls()
     return _global_queue
 
 
-def enqueue(job: Job):
-    """
-    Add a job to the queue.
-    """
+# --------------------------------------------------------------------------- #
+#  Thin convenience wrappers
+# --------------------------------------------------------------------------- #
+def enqueue(job: Job) -> None:
+    """Add a job to the active queue backend."""
     get_queue_backend().enqueue(job)
 
 
 def dequeue(timeout: int = 1) -> Optional[Job]:
-    """
-    Remove and return a job from the queue, blocking up to `timeout` seconds.
-    """
+    """Remove & return a job, blocking up to ``timeout`` seconds."""
     return get_queue_backend().dequeue(timeout)
 
 
 def pop_batch(batch_size: int = 1, timeout: int = 1) -> List[Job]:
-    """
-    Remove and return up to `batch_size` jobs from the queue.
-    """
+    """Remove & return up to ``batch_size`` jobs."""
     return get_queue_backend().pop_batch(batch_size=batch_size, timeout=timeout)
 
 
 def qsize() -> int:
-    """
-    Return the number of jobs currently in the queue.
-    """
+    """Return the current queue length."""
     return get_queue_backend().qsize()
 
 
 def clear() -> int:
     """
-    Clear all jobs from the queue.
-    Returns the number of jobs cleared.
+    Remove **all** jobs from the backend.
+
+    Returns
+    -------
+    int
+        Number of jobs removed.
     """
     return get_queue_backend().clear()

--- a/nuvom/queue_backends/file_queue.py
+++ b/nuvom/queue_backends/file_queue.py
@@ -20,7 +20,7 @@ from nuvom.queue_backends.base import BaseJobQueue
 from nuvom.serialize import serialize, deserialize
 from nuvom.utils.file_utils.safe_remove import safe_remove
 from nuvom.log import logger
-
+from nuvom.plugins.contracts import Plugin, API_VERSION
 
 class FileJobQueue(BaseJobQueue):
     """
@@ -30,6 +30,16 @@ class FileJobQueue(BaseJobQueue):
         dir (str): Directory path where job files are stored.
         lock (Lock): Thread lock to synchronize queue operations.
     """
+    
+     # --- Plugin metadata --------------------------------------------------
+    api_version = API_VERSION
+    name        = "memory"
+    provides    = ["queue_backend"]
+    requires: list[str] = []
+
+    # start/stop are no‑ops for this lightweight backend
+    def start(self, settings: dict): ...
+    def stop(self): ...
 
     def __init__(self, directory: str = "nuvom_queue"):
         """

--- a/nuvom/queue_backends/memory_queue.py
+++ b/nuvom/queue_backends/memory_queue.py
@@ -14,8 +14,9 @@ from nuvom.serialize import get_serializer
 from nuvom.job import Job
 from nuvom.log import logger
 from nuvom.plugins.contracts import Plugin, API_VERSION
+from nuvom.queue_backends.base import BaseJobQueue
 
-class MemoryJobQueue:
+class MemoryJobQueue(BaseJobQueue):
     """
     An in-memory job queue backed by queue.Queue with thread safety.
 

--- a/nuvom/queue_backends/memory_queue.py
+++ b/nuvom/queue_backends/memory_queue.py
@@ -13,7 +13,7 @@ import threading
 from nuvom.serialize import get_serializer
 from nuvom.job import Job
 from nuvom.log import logger
-
+from nuvom.plugins.contracts import Plugin, API_VERSION
 
 class MemoryJobQueue:
     """
@@ -24,6 +24,15 @@ class MemoryJobQueue:
         lock (threading.Lock): Lock to synchronize batch operations.
         serializer: Serializer instance (currently unused but reserved).
     """
+     # --- Plugin metadata --------------------------------------------------
+    api_version = API_VERSION
+    name        = "memory"
+    provides    = ["queue_backend"]
+    requires: list[str] = []
+
+    # start/stop are no‑ops for this lightweight backend
+    def start(self, settings: dict): ...
+    def stop(self): ...
 
     def __init__(self, maxsize: int = 0):
         """

--- a/nuvom/result_backends/file_backend.py
+++ b/nuvom/result_backends/file_backend.py
@@ -13,6 +13,7 @@ from typing import Optional, Any
 
 from nuvom.result_backends.base import BaseResultBackend
 from nuvom.serialize import serialize, deserialize
+from nuvom.plugins.contracts import Plugin, API_VERSION
 
 
 class FileResultBackend(BaseResultBackend):
@@ -26,9 +27,19 @@ class FileResultBackend(BaseResultBackend):
         result_dir (str): Directory for all job result files.
     """
 
+    # --- Plugin metadata --------------------------------------------------
+    api_version = API_VERSION
+    name        = "memory"
+    provides    = ["queue_backend"]
+    requires: list[str] = []
+    
     def __init__(self):
         self.result_dir = "job_results"
         os.makedirs(self.result_dir, exist_ok=True)
+
+    # start/stop are no‑ops for this lightweight backend
+    def start(self, settings: dict): ...
+    def stop(self): ...
 
     def _path(self, job_id, ext: str = "meta") -> str:
         """Construct the full file path for a job's metadata file."""

--- a/nuvom/result_backends/memory_backend.py
+++ b/nuvom/result_backends/memory_backend.py
@@ -13,7 +13,7 @@ from typing import List, Dict
 
 from nuvom.serialize import serialize, deserialize
 from nuvom.result_backends.base import BaseResultBackend
-
+from nuvom.plugins.contracts import Plugin, API_VERSION
 
 class MemoryResultBackend(BaseResultBackend):
     """
@@ -31,6 +31,16 @@ class MemoryResultBackend(BaseResultBackend):
 
     def __init__(self):
         self._store = {}
+
+     # --- Plugin metadata --------------------------------------------------
+    api_version = API_VERSION
+    name        = "memory"
+    provides    = ["queue_backend"]
+    requires: list[str] = []
+
+    # start/stop are no‑ops for this lightweight backend
+    def start(self, settings: dict): ...
+    def stop(self): ...
 
     def set_result(self, job_id, func_name, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None, completed_at=None):
         """

--- a/nuvom/result_backends/sqlite_backend.py
+++ b/nuvom/result_backends/sqlite_backend.py
@@ -27,7 +27,7 @@ from typing import Any, Optional, Dict, List
 from nuvom.serialize import serialize, deserialize
 from nuvom.result_backends.base import BaseResultBackend
 from nuvom.log import logger
-
+from nuvom.plugins.contracts import Plugin, API_VERSION
 
 _SQLITE_THREAD_LOCAL = threading.local()
 
@@ -83,6 +83,16 @@ class SQLiteResultBackend(BaseResultBackend):
     def __init__(self, db_path: str | Path | None = None) -> None:
         self.db_path = Path(db_path or ".nuvom/nuvom.db")
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+     # --- Plugin metadata --------------------------------------------------
+    api_version = API_VERSION
+    name        = "memory"
+    provides    = ["queue_backend"]
+    requires: list[str] = []
+
+    # start/stop are no‑ops for this lightweight backend
+    def start(self, settings: dict): ...
+    def stop(self): ...
 
     def set_result(
         self,

--- a/nuvom/result_backends/sqlite_backend.py
+++ b/nuvom/result_backends/sqlite_backend.py
@@ -1,0 +1,217 @@
+# nuvom/result_backend/sqlite_backend.py
+
+"""
+SQLiteResultBackend
+~~~~~~~~~~~~~~~~~~~
+Durable, zero-infra result backend that stores all job metadata in a single
+SQLite database file (default: ``.nuvom/nuvom.db``).
+
+Key design goals
+----------------
+* Full parity with Memory/File backends (`get_result`, `get_error`, `get_full`,
+  `list_jobs`)
+* Safe for concurrent threaded access (single connection per thread via
+  `sqlite3.Connection` + WAL mode)
+* Uses msgpack to store `args`, `kwargs`, and `result` blobs
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional, Dict, List
+
+from nuvom.serialize import serialize, deserialize
+from nuvom.result_backends.base import BaseResultBackend
+from nuvom.log import logger
+
+
+_SQLITE_THREAD_LOCAL = threading.local()
+
+
+def _get_connection(db_path: Path) -> sqlite3.Connection:
+    """
+    Return a thread-local SQLite connection in WAL mode.
+
+    The first caller will create the database file and schema if needed.
+    """
+    if not hasattr(_SQLITE_THREAD_LOCAL, "conn"):
+        logger.debug("Opening SQLite connection to %s", db_path)
+        conn = sqlite3.connect(str(db_path), detect_types=sqlite3.PARSE_DECLTYPES)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.row_factory = sqlite3.Row
+        _SQLITE_THREAD_LOCAL.conn = conn
+
+        # Cheap schema-exists check
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobs (
+                job_id        TEXT PRIMARY KEY,
+                func_name     TEXT,
+                args          BLOB,
+                kwargs        BLOB,
+                status        TEXT,
+                result        BLOB,
+                error_type    TEXT,
+                error_msg     TEXT,
+                traceback     TEXT,
+                attempts      INTEGER,
+                retries_left  INTEGER,
+                timeout_secs  INTEGER,
+                created_at    REAL,
+                completed_at  REAL
+            );
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_status_created ON jobs (status, created_at DESC);")
+    return _SQLITE_THREAD_LOCAL.conn  # type: ignore[attr-defined]
+
+
+class SQLiteResultBackend(BaseResultBackend):
+    """
+    SQLite-based backend storing every job in a single `jobs` table.
+
+    Parameters
+    ----------
+    db_path : str | Path
+        Location of the SQLite database file. Defaults to ``.nuvom/nuvom.db``.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self.db_path = Path(db_path or ".nuvom/nuvom.db")
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def set_result(
+        self,
+        job_id: str,
+        func_name: str,
+        result: Any,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ) -> None:
+        conn = _get_connection(self.db_path)
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                job_id, func_name, args, kwargs,
+                status, result, attempts, retries_left,
+                created_at, completed_at
+            ) VALUES (
+                :job_id, :func_name, :args, :kwargs,
+                'SUCCESS', :result, :attempts, :retries_left,
+                :created_at, :completed_at
+            )
+            ON CONFLICT(job_id) DO UPDATE SET
+                status       = 'SUCCESS',
+                result       = excluded.result,
+                completed_at = excluded.completed_at;
+            """,
+            {
+                "job_id": job_id,
+                "func_name": func_name,
+                "args": serialize(args or ()),
+                "kwargs": serialize(kwargs or {}),
+                "result": serialize(result),
+                "attempts": attempts,
+                "retries_left": retries_left,
+                "created_at": created_at or time.time(),
+                "completed_at": completed_at or time.time(),
+            },
+        )
+        conn.commit()
+
+    def get_result(self, job_id: str) -> Any | None:
+        row = _get_connection(self.db_path).execute(
+            "SELECT result FROM jobs WHERE job_id=? AND status='SUCCESS';", (job_id,)
+        ).fetchone()
+        return deserialize(row["result"]) if row else None  # type: ignore[index]
+
+    def set_error(
+        self,
+        job_id: str,
+        func_name: str,
+        error: Exception,
+        *,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None,
+        retries_left: Optional[int] = None,
+        attempts: Optional[int] = None,
+        created_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ) -> None:
+        conn = _get_connection(self.db_path)
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                job_id, func_name, args, kwargs,
+                status, error_type, error_msg, traceback,
+                attempts, retries_left, created_at, completed_at
+            ) VALUES (
+                :job_id, :func_name, :args, :kwargs,
+                'FAILED', :etype, :emsg, :tb,
+                :attempts, :retries_left, :created_at, :completed_at
+            )
+            ON CONFLICT(job_id) DO UPDATE SET
+                status       = 'FAILED',
+                error_type   = excluded.error_type,
+                error_msg    = excluded.error_msg,
+                traceback    = excluded.traceback,
+                completed_at = excluded.completed_at;
+            """,
+            {
+                "job_id": job_id,
+                "func_name": func_name,
+                "args": serialize(args or ()),
+                "kwargs": serialize(kwargs or {}),
+                "etype": type(error).__name__,
+                "emsg": str(error),
+                "tb": getattr(error, "__traceback__", None) if isinstance(error, Exception) else "",
+                "attempts": attempts,
+                "retries_left": retries_left,
+                "created_at": created_at or time.time(),
+                "completed_at": completed_at or time.time(),
+            },
+        )
+        conn.commit()
+
+    def get_error(self, job_id: str) -> Optional[str]:
+        row = _get_connection(self.db_path).execute(
+            "SELECT error_msg FROM jobs WHERE job_id=? AND status='FAILED';", (job_id,)
+        ).fetchone()
+        return row["error_msg"] if row else None  # type: ignore[index]
+
+    def get_full(self, job_id: str) -> Optional[Dict]:
+        row = _get_connection(self.db_path).execute(
+            "SELECT * FROM jobs WHERE job_id=?;", (job_id,)
+        ).fetchone()
+        if not row:
+            return None
+        data = dict(row)
+        # Deserialize blobs for readability
+        data["args"] = deserialize(data["args"])
+        data["kwargs"] = deserialize(data["kwargs"])
+        if data["result"] is not None:
+            data["result"] = deserialize(data["result"])
+        return data
+
+    def list_jobs(self) -> List[Dict]:
+        rows = _get_connection(self.db_path).execute(
+            "SELECT * FROM jobs ORDER BY created_at DESC;"
+        ).fetchall()
+        output = []
+        for r in rows:
+            record = dict(r)
+            record["args"] = deserialize(record["args"])
+            record["kwargs"] = deserialize(record["kwargs"])
+            if record["result"] is not None:
+                record["result"] = deserialize(record["result"])
+            output.append(record)
+        return output

--- a/nuvom/result_store.py
+++ b/nuvom/result_store.py
@@ -8,44 +8,59 @@ storing results, fetching them, and managing backend lifecycle.
 from nuvom.config import get_settings
 from nuvom.result_backends.file_backend import FileResultBackend
 from nuvom.result_backends.memory_backend import MemoryResultBackend
+from nuvom.result_backends.sqlite_backend import SQLiteResultBackend  # NEW ✅
 
 _backend = None
 
 
 def get_backend():
     """
-    Returns the active result backend, initializing it if necessary.
+    Return the active result backend (singleton).  
+    Lazily instantiates the backend based on ``NUVOM_RESULT_BACKEND``.
     """
     global _backend
     if _backend is not None:
         return _backend
 
-    backend_name = get_settings().result_backend.lower()
+    settings = get_settings()
+    backend_name = settings.result_backend.lower()
 
     if backend_name == "file":
         _backend = FileResultBackend()
     elif backend_name == "memory":
         _backend = MemoryResultBackend()
+    elif backend_name == "sqlite":                      # NEW ✅
+        _backend = SQLiteResultBackend(settings.sqlite_db_path)
     else:
         raise ValueError(f"Unsupported result backend: {backend_name}")
 
     return _backend
 
 
+# ---------------------------------------------------------------------------#
+# Convenience wrappers that push full metadata into whichever backend is set #
+# ---------------------------------------------------------------------------#
 def reset_backend():
-    """
-    Resets the backend instance (for testing or config reload).
-    """
+    """Reset the cached backend instance (used by tests)."""
     global _backend
     _backend = None
 
 
-def set_result(job_id, func_name, result, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None, completed_at=None):
-    """
-    Store the result for a given job ID, with full metadata.
-    """
+def set_result(
+    job_id,
+    func_name,
+    result,
+    *,
+    args=None,
+    kwargs=None,
+    retries_left=None,
+    attempts=None,
+    created_at=None,
+    completed_at=None,
+):
+    """Persist a successful job result with full metadata."""
     get_backend().set_result(
-        job_id=job_id, 
+        job_id=job_id,
         func_name=func_name,
         result=result,
         args=args,
@@ -58,17 +73,23 @@ def set_result(job_id, func_name, result, *, args=None, kwargs=None, retries_lef
 
 
 def get_result(job_id):
-    """
-    Retrieve the result for a given job ID.
-    """
+    """Retrieve only the deserialized result value (or ``None``)."""
     return get_backend().get_result(job_id)
 
 
-
-def set_error(job_id, func_name, error, *, args=None, kwargs=None, retries_left=None, attempts=None, created_at=None, completed_at=None):
-    """
-    Store an error for a given job ID, with full metadata.
-    """
+def set_error(
+    job_id,
+    func_name,
+    error,
+    *,
+    args=None,
+    kwargs=None,
+    retries_left=None,
+    attempts=None,
+    created_at=None,
+    completed_at=None,
+):
+    """Persist a failed job’s error with traceback and metadata."""
     get_backend().set_error(
         job_id=job_id,
         func_name=func_name,
@@ -78,11 +99,10 @@ def set_error(job_id, func_name, error, *, args=None, kwargs=None, retries_left=
         retries_left=retries_left,
         attempts=attempts,
         created_at=created_at,
-        completed_at=completed_at
+        completed_at=completed_at,
     )
 
+
 def get_error(job_id):
-    """
-    Retrieve the error message for a given job ID.
-    """
+    """Return the stored error message (or ``None``)."""
     return get_backend().get_error(job_id)

--- a/nuvom/result_store.py
+++ b/nuvom/result_store.py
@@ -1,55 +1,80 @@
 # nuvom/result_store.py
 
 """
-Central access point for result backend operations:
-storing results, fetching them, and managing backend lifecycle.
+Central access point for result‑backend operations.
+
+Key changes in v0.9
+-------------------
+1.  **Registry‑based resolution** – `get_backend()` now looks up the backend
+    class in `nuvom.plugins.registry` *after* ensuring all plugins are loaded.
+2.  **Plugin auto‑load** – calls `nuvom.plugins.loader.load_plugins()` once.
+3.  **Built‑in backends registered via registry** – direct imports of
+    `FileResultBackend`, `MemoryResultBackend`, … are no longer required here;
+    they’re registered in `plugins.registry._register_builtin_backends()`.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from nuvom.config import get_settings
-from nuvom.result_backends.file_backend import FileResultBackend
-from nuvom.result_backends.memory_backend import MemoryResultBackend
-from nuvom.result_backends.sqlite_backend import SQLiteResultBackend  # NEW ✅
+from nuvom.log import logger
+from nuvom.plugins.loader import load_plugins
+from nuvom.plugins.registry import get_result_backend_cls
 
-_backend = None
+_backend = None  # singleton instance
 
 
+# --------------------------------------------------------------------------- #
+#  Backend factory
+# --------------------------------------------------------------------------- #
 def get_backend():
     """
-    Return the active result backend (singleton).  
-    Lazily instantiates the backend based on ``NUVOM_RESULT_BACKEND``.
+    Return the active result backend (singleton).
+
+    Resolution order
+    ----------------
+    1. Load plugins (idempotent).
+    2. Ask the **registry** for a backend class matching
+       ``NUVOM_RESULT_BACKEND``.
+    3. Instantiate it – passing ``sqlite_db_path`` fo SQLite.
     """
     global _backend
     if _backend is not None:
         return _backend
 
     settings = get_settings()
+    load_plugins()  # ensure plugin modules have registered their backends
+
     backend_name = settings.result_backend.lower()
+    backend_cls = get_result_backend_cls(backend_name)
 
-    if backend_name == "file":
-        _backend = FileResultBackend()
-    elif backend_name == "memory":
-        _backend = MemoryResultBackend()
-    elif backend_name == "sqlite":                      # NEW ✅
-        _backend = SQLiteResultBackend(settings.sqlite_db_path)
+    if backend_cls is None:  # still unknown → hard error
+        raise ValueError(f"Unsupported result backend: '{backend_name}'")
+
+    # Special‑case constructor kwargs (only SQLite for now)
+    if backend_name == "sqlite":
+        _backend = backend_cls(settings.sqlite_db_path or ".nuvom/nuvom.db")
     else:
-        raise ValueError(f"Unsupported result backend: {backend_name}")
+        _backend = backend_cls()  # type: ignore[call-arg]
 
+    logger.info("[ResultStore] Using %s backend (%s)", backend_name, backend_cls.__name__)
     return _backend
 
 
-# ---------------------------------------------------------------------------#
-# Convenience wrappers that push full metadata into whichever backend is set #
-# ---------------------------------------------------------------------------#
-def reset_backend():
-    """Reset the cached backend instance (used by tests)."""
+def reset_backend() -> None:
+    """Clear the cached backend instance (primarily for tests)."""
     global _backend
     _backend = None
 
 
+# --------------------------------------------------------------------------- #
+#  Convenience wrappers – preserve existing call‑site API
+# --------------------------------------------------------------------------- #
 def set_result(
-    job_id,
-    func_name,
-    result,
+    job_id: str,
+    func_name: str,
+    result: Any,
     *,
     args=None,
     kwargs=None,
@@ -57,8 +82,7 @@ def set_result(
     attempts=None,
     created_at=None,
     completed_at=None,
-):
-    """Persist a successful job result with full metadata."""
+) -> None:
     get_backend().set_result(
         job_id=job_id,
         func_name=func_name,
@@ -72,15 +96,14 @@ def set_result(
     )
 
 
-def get_result(job_id):
-    """Retrieve only the deserialized result value (or ``None``)."""
+def get_result(job_id: str):
     return get_backend().get_result(job_id)
 
 
 def set_error(
-    job_id,
-    func_name,
-    error,
+    job_id: str,
+    func_name: str,
+    error: Exception,
     *,
     args=None,
     kwargs=None,
@@ -88,8 +111,7 @@ def set_error(
     attempts=None,
     created_at=None,
     completed_at=None,
-):
-    """Persist a failed job’s error with traceback and metadata."""
+) -> None:
     get_backend().set_error(
         job_id=job_id,
         func_name=func_name,
@@ -103,6 +125,5 @@ def set_error(
     )
 
 
-def get_error(job_id):
-    """Return the stored error message (or ``None``)."""
+def get_error(job_id: str):
     return get_backend().get_error(job_id)

--- a/nuvom/worker.py
+++ b/nuvom/worker.py
@@ -1,124 +1,174 @@
 # nuvom/worker.py
 
+"""
+nuvom.worker
+~~~~~~~~~~~~
+Thread-based worker pool with *graceful* lifecycle management.
+
+Key upgrades (v0.9):
+    • SIGINT / SIGTERM are trapped and routed to a global ``_shutdown_event``.
+    • Workers stop polling once the event is set *and* their personal queue is empty.
+    • Dispatcher stops once the event is set and all jobs are assigned.
+    • Clean join() logic prints progress and guarantees no thread leak.
+"""
+
+from __future__ import annotations
+
+import queue
+import signal
 import threading
 import time
-import queue
 from typing import List
 
 from nuvom.config import get_settings
-from nuvom.queue import get_queue_backend
-from nuvom.result_store import set_result, set_error
 from nuvom.execution.job_runner import JobRunner
+from nuvom.log import logger
+from nuvom.queue import get_queue_backend
 from nuvom.registry.auto_register import auto_register_from_manifest
-from nuvom.log import logger  # ✅ Use rich-powered logger
 
-_shutdown_event = threading.Event()
+# ------------------------------------------------------------------------- #
+_shutdown_event = threading.Event()          # Global stop-flag for all threads
+# ------------------------------------------------------------------------- #
 
 
 class WorkerThread(threading.Thread):
     """
-    A worker that runs in its own thread, pulls jobs from a personal queue,
-    and executes them using JobRunner. It tracks its current load.
+    Dedicated worker that pulls jobs from an *in-memory* queue injected by the
+    dispatcher. It finishes outstanding work before exiting.
+
+    Attributes
+    ----------
+    worker_id : int
+        Logical identifier used for logs.
+    job_timeout : int
+        Default timeout passed to JobRunner.
     """
-    def __init__(self, worker_id: int, job_timeout: int):
-        super().__init__(daemon=True)
+
+    def __init__(self, worker_id: int, job_timeout: int) -> None:
+        super().__init__(daemon=True, name=f"Worker-{worker_id}")
         self.worker_id = worker_id
         self.job_timeout = job_timeout
-        self._job_queue = queue.Queue()
+        self._job_queue: queue.Queue = queue.Queue()
         self._in_flight = 0
         self._lock = threading.Lock()
 
-    def run(self):
-        logger.info(f"[Worker-{self.worker_id}] Online.")
+    # ------------------------------------------------------------------ #
+    # Public helpers
+    # ------------------------------------------------------------------ #
+    def submit(self, job) -> None:
+        """Push a job into this worker’s personal queue."""
+        self._job_queue.put(job)
 
-        while not _shutdown_event.is_set():
+    def load(self) -> int:
+        """Current number of in-flight jobs."""
+        with self._lock:
+            return self._in_flight
+
+    # ------------------------------------------------------------------ #
+    # Thread body
+    # ------------------------------------------------------------------ #
+    def run(self) -> None:  # noqa: D401 – documented above
+        logger.info("[Worker-%s] Online.", self.worker_id)
+
+        while True:
+            # Break when shutdown is requested AND queue is empty
+            if _shutdown_event.is_set() and self._job_queue.empty():
+                logger.info("[Worker-%s] Drained – shutting down.", self.worker_id)
+                break
+
             try:
-                job = self._job_queue.get(timeout=0.5)
+                job = self._job_queue.get(timeout=0.25)
             except queue.Empty:
                 continue
 
             with self._lock:
                 self._in_flight += 1
 
-            logger.debug(f"[Worker-{self.worker_id}] Executing job {job.id} ({job.func_name})")
+            logger.debug("[Worker-%s] Executing job %s (%s)", self.worker_id, job.id, job.func_name)
 
-            runner = JobRunner(job, worker_id=self.worker_id, default_timeout=self.job_timeout)
-            runner.run()
+            JobRunner(job, self.worker_id, self.job_timeout).run()
 
-            logger.info(f"[Worker-{self.worker_id}] Completed {runner.job.func_name} → {runner.job.result}")
+            logger.info("[Worker-%s] Completed %s → %s", self.worker_id, job.func_name, job.result)
 
             with self._lock:
                 self._in_flight -= 1
 
-    def submit(self, job):
-        self._job_queue.put(job)
-
-    def load(self) -> int:
-        with self._lock:
-            return self._in_flight
-
 
 class DispatcherThread(threading.Thread):
     """
-    Dispatcher pulls job batches from the queue and assigns them to the
-    least-loaded WorkerThread.
+    Dispatcher polls the *shared queue backend* and assigns jobs to the
+    least-loaded worker. It respects *retry_delay* and halts on shutdown.
     """
-    def __init__(self, workers: List[WorkerThread], batch_size: int, job_timeout: int):
-        super().__init__(daemon=True)
+
+    def __init__(self, workers: List[WorkerThread], batch_size: int, job_timeout: int) -> None:
+        super().__init__(daemon=True, name="Dispatcher")
         self.workers = workers
         self.batch_size = batch_size
         self.job_timeout = job_timeout
         self.queue = get_queue_backend()
 
-    def run(self):
+    def run(self) -> None:  # noqa: D401 – documented above
         logger.info("[Dispatcher] Started.")
 
         while not _shutdown_event.is_set():
-            jobs = self.queue.pop_batch(batch_size=self.batch_size, timeout=self.job_timeout)
+            jobs = self.queue.pop_batch(self.batch_size, timeout=1)
             if not jobs:
                 continue
 
             for job in jobs:
-                if job.next_retry_at and job.next_retry_at > time.time():
-                    # Not ready – push back into queue
+                # Retry-delay handling
+                if getattr(job, "next_retry_at", 0) and (job.next_retry_at or 0) > time.time():
                     self.queue.enqueue(job)
                     continue
-                
+
                 target = min(self.workers, key=lambda w: w.load())
                 target.submit(job)
-                logger.debug(f"[Dispatcher] Job {job.id} → Worker-{target.worker_id}")
+                logger.debug("[Dispatcher] Job %s → Worker-%s", job.id, target.worker_id)
+
+        logger.info("[Dispatcher] Shutdown signal received – exiting.")
 
 
-def start_worker_pool():
+# ------------------------------------------------------------------------- #
+# Graceful Pool Entrypoint
+# ------------------------------------------------------------------------- #
+def _install_signal_handlers() -> None:
+    """Map SIGINT/SIGTERM to the global _shutdown_event."""
+
+    def _handler(signum, _frame):  # noqa: D401 – small internal func
+        logger.warning("[Signal] %s received – initiating graceful shutdown.", signal.Signals(signum).name)
+        _shutdown_event.set()
+
+    signal.signal(signal.SIGINT, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+
+
+def start_worker_pool() -> None:
     """
-    Initializes the worker pool and starts the dispatcher loop.
-    Auto-registers tasks, then spawns workers and dispatcher.
+    Bootstrap the worker pool, run until Ctrl-C / SIGTERM, then
+    drain gracefully and exit.
     """
     auto_register_from_manifest()
+    _install_signal_handlers()
 
-    settings = get_settings()
-    max_workers = settings.max_workers
-    batch_size = settings.batch_size
-    job_timeout = settings.job_timeout_secs
+    cfg = get_settings()
+    workers: list[WorkerThread] = [
+        WorkerThread(i, job_timeout=cfg.job_timeout_secs) for i in range(cfg.max_workers)
+    ]
+    for w in workers:
+        w.start()
 
-    logger.info(f"[Nuvom] Spawning {max_workers} smart workers...")
-
-    workers = []
-    for i in range(max_workers):
-        worker = WorkerThread(worker_id=i, job_timeout=job_timeout)
-        worker.start()
-        workers.append(worker)
-
-    dispatcher = DispatcherThread(workers=workers, batch_size=batch_size, job_timeout=job_timeout)
+    dispatcher = DispatcherThread(workers, batch_size=cfg.batch_size, job_timeout=cfg.job_timeout_secs)
     dispatcher.start()
 
     try:
-        while not _shutdown_event.is_set():
-            time.sleep(1)
-    except KeyboardInterrupt:
-        logger.warning("[Shutdown] Interrupt received. Cleaning up...")
+        while dispatcher.is_alive():
+            dispatcher.join(timeout=0.5)
+    finally:
+        # Make sure global flag is set (covers KeyboardInterrupt path)
         _shutdown_event.set()
-        dispatcher.join()
+        logger.info("[Pool] Awaiting %d worker threads…", len(workers))
+
         for w in workers:
             w.join()
-        logger.info("[Nuvom] All workers stopped cleanly.")
+
+        logger.info("[Pool] All workers stopped cleanly.")

--- a/nuvom/worker.py
+++ b/nuvom/worker.py
@@ -25,6 +25,8 @@ from nuvom.execution.job_runner import JobRunner
 from nuvom.log import logger
 from nuvom.queue import get_queue_backend
 from nuvom.registry.auto_register import auto_register_from_manifest
+from nuvom.plugins.loader import LOADED_PLUGINS
+from nuvom.plugins.loader import shutdown_plugins
 
 # ------------------------------------------------------------------------- #
 _shutdown_event = threading.Event()          # Global stop-flag for all threads
@@ -172,3 +174,7 @@ def start_worker_pool() -> None:
             w.join()
 
         logger.info("[Pool] All workers stopped cleanly.")
+        
+        # SHUT-DOWN all loaded plugins
+        shutdown_plugins()
+        logger.info("[Pool] Plugin shutdown complete.")

--- a/run.py
+++ b/run.py
@@ -1,5 +1,0 @@
-# run.py
-from nuvom.cli.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,32 +1,46 @@
-# tests/conftest.py  (replaces the _nuvom_test_safety fixture)
+# tests/conftest.py  (only the parts that changed)
 
-import pytest, threading
-from nuvom.queue import clear as clear_queue
-from nuvom.registry.registry import get_task_registry
+import importlib
+import threading
+import pytest
+
 from nuvom.config import override_settings
+from nuvom.queue import clear as clear_queue, reset_backend as reset_q_backend
+from nuvom.result_store import reset_backend as reset_result_backend
+from nuvom.registry.registry import get_task_registry
 from nuvom.worker import _shutdown_event
+from nuvom.plugins import loader as plugload, registry as plugreg
+import nuvom.queue as nuvo_queue
+
 
 @pytest.fixture(autouse=True)
 def nuvom_isolate():
-    """
-    • Force in-memory back-ends<br>
-    • Stop stray worker threads<br>
-    • **Do NOT wipe the TaskRegistry at setup** – tasks declared with @task
-      in a test module stay registered for that test.<br>
-    • Still clean queue + registry **after** each test.
-    """
+    # ── SET‑UP ──────────────────────────────────────────────────────────
     override_settings(queue_backend="memory", result_backend="memory")
+    reset_result_backend()          # fresh MemoryResultBackend
+    reset_q_backend()               # clear queue singleton
+    plugload._LOADED.clear()
 
+    importlib.reload(nuvo_queue)    # make queue.py re‑resolve backend
+
+    # stop any stray worker / dispatcher threads
     _shutdown_event.set()
     for t in list(threading.enumerate()):
         if t.name.startswith(("Worker-", "Dispatcher")):
             t.join(timeout=0.5)
     _shutdown_event.clear()
 
-    clear_queue()                    # queue clean
-    yield                             # --- test runs here ---
-
-    # teardown: full cleanup for next test
+    plugreg._reset_for_tests()
+    clear_queue()
+    
+    yield
+    
+    # ── TEAR‑DOWN ───────────────────────────────────────────────────────
     _shutdown_event.set()
     clear_queue()
     get_task_registry().clear()
+    reset_result_backend()
+    reset_q_backend()
+    
+    plugload._LOADED.clear()
+    plugreg._reset_for_tests()

--- a/tests/test_cli/test_plugin_scaffold.py
+++ b/tests/test_cli/test_plugin_scaffold.py
@@ -1,0 +1,17 @@
+# tests/test_cli/test_plugin_scaffold.py
+
+import shutil
+from pathlib import Path
+from nuvom.cli.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+def test_plugin_scaffold_creates_file(tmp_path):
+    plugin_name = "custom_plugin"
+    result = runner.invoke(app, ["plugin", "scaffold", plugin_name, "--out", str(tmp_path)])
+    
+    file_path = tmp_path / f"{plugin_name}.py"
+    assert result.exit_code == 0
+    assert file_path.exists()
+    assert "class CustomPlugin(Plugin):" in file_path.read_text()

--- a/tests/test_cli/test_plugin_status.py
+++ b/tests/test_cli/test_plugin_status.py
@@ -1,0 +1,46 @@
+# tests/test_cli/test_plugin_status.py
+
+from typer.testing import CliRunner
+import pytest
+
+from nuvom.cli.cli import app
+
+runner = CliRunner()
+
+@pytest.fixture(autouse=True)
+def reset_plugins():
+    """
+    Test isolation: clear plugin registry and loader cache before each test.
+    """
+    from nuvom.plugins.registry import REGISTRY
+    from nuvom.plugins.loader import _LOADED
+
+    REGISTRY._caps.clear()       # wipe registry state
+    _LOADED.clear()              # force re‑load on next call
+
+    yield                        # ← test runs here
+
+    REGISTRY._caps.clear()
+    _LOADED.clear()
+
+
+def test_plugin_status_prints_table():
+    """
+    Ensure `nuvom plugin status` prints a table and exits cleanly.
+    """
+    result = runner.invoke(app, ["plugin", "status"])
+    assert result.exit_code == 0
+    assert "Capability" in result.output
+    assert "Name" in result.output
+    assert "Provider" in result.output
+    assert "Loaded At" in result.output
+
+
+def test_plugin_status_no_plugins(monkeypatch):
+    """
+    Simulate no plugins registered — should print 'No plugins loaded.'
+    """
+    monkeypatch.setattr("nuvom.plugins.registry.REGISTRY._caps", {})
+    result = runner.invoke(app, ["plugin", "status"])
+    assert result.exit_code == 0
+    assert "No plugins loaded" in result.output

--- a/tests/test_cli/test_plugin_test.py
+++ b/tests/test_cli/test_plugin_test.py
@@ -1,0 +1,41 @@
+# tests/test_cli/test_plugin_test.py
+
+from pathlib import Path
+import textwrap
+from typer.testing import CliRunner
+from nuvom.cli.cli import app
+
+runner = CliRunner()
+
+
+def test_plugin_test_passes(tmp_path: Path):
+    """
+    Create a minimal Plugin implementation on disk and run:
+
+        nuvom plugin test <file>
+
+    Expect: exit‑code 0 and success message in output.
+    """
+    plugin_file = tmp_path / "test_plugin.py"
+    plugin_file.write_text(
+        textwrap.dedent(
+            """
+            from nuvom.plugins.contracts import Plugin
+
+            class TestPlugin(Plugin):
+                api_version = "1.0"
+                name = "test_plugin"
+                provides = ["queue_backend"]
+                requires = []
+
+                def start(self, settings): ...
+                def stop(self): ...
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["plugin", "test", str(plugin_file)])
+
+    assert result.exit_code == 0
+    assert "✅ Plugin test_plugin validated successfully." in result.output

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,116 @@
+# tests/test_plugins.py
+
+"""
+Tests for Nuvom’s plugin system (registry + loader).
+
+These tests spin up fake modules on sys.modules so we don’t need real files.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from pathlib import Path
+import tomllib
+import textwrap
+
+import pytest
+
+from nuvom.plugins import registry as plugreg
+from nuvom.plugins import loader as plugload
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+def _fake_module(name: str, register_calls: list[str], *, as_queue=False):
+    """
+    Create an in‑memory module with optional `register()` callable.
+    If `as_queue=True`, the register() will add a dummy queue backend.
+    """
+    mod = ModuleType(name)
+    if as_queue:
+
+        class DummyQueue:
+            def enqueue(self, *_): ...
+            def dequeue(self, *_): ...
+            def pop_batch(self, *_): return []
+            def qsize(self): return 0
+            def clear(self): return 0
+
+        def _reg():
+            plugreg.register_queue_backend("dummy", DummyQueue, override=True)
+            register_calls.append("called")
+
+        mod.register = _reg  # type: ignore[attr-defined]
+
+    sys.modules[name] = mod
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+#  Tests
+# --------------------------------------------------------------------------- #
+def test_registry_basic_registration():
+    class MemBackend: ...
+    plugreg.register_result_backend("mydb", MemBackend, override=True)
+    assert plugreg.get_result_backend_cls("mydb") is MemBackend
+
+    # Duplicate without override should raise
+    with pytest.raises(ValueError):
+        plugreg.register_result_backend("mydb", MemBackend)
+
+
+def test_loader_imports_and_register(tmp_path: Path, monkeypatch):
+    """
+    • Write a .nuvom_plugins.toml pointing to a fake module
+    • Ensure loader imports it and the module’s register() runs
+    """
+    calls: list[str] = []
+    _fake_module("myplugin.mod", calls, as_queue=True)
+
+    cfg = tmp_path / ".nuvom_plugins.toml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            [plugins]
+            modules = ["myplugin.mod"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Monkey‑patch loader to look at tmp_path
+    monkeypatch.setattr(plugload, "_CONFIG_PATH", cfg)
+
+    plugload.load_plugins()
+    assert "myplugin.mod" in plugload._PLUGINS_LOADED
+    assert calls == ["called"]  # register() executed
+    assert plugreg.get_queue_backend_cls("dummy") is not None
+
+
+def test_queue_resolution_with_plugin(monkeypatch):
+    """
+    queue.get_queue_backend() should be able to resolve a queue backend
+    registered by a plugin.
+    """
+    from nuvom import queue as nuv_queue
+    from nuvom.config import override_settings
+
+    class InMem:  # minimal “backend”
+        def enqueue(self, *_): ...
+        def dequeue(self, *_): return None
+        def pop_batch(self, *_): return []
+        def qsize(self): return 0
+        def clear(self): return 0
+
+    plugreg.register_queue_backend("plugmem", InMem, override=True)
+    override_settings(queue_backend="plugmem")
+
+    # Fresh import to force function to re‑resolve backend
+    import importlib
+    importlib.reload(nuv_queue)
+
+    backend = nuv_queue.get_queue_backend()
+    assert isinstance(backend, InMem)

--- a/tests/test_plugins/test_loader.py
+++ b/tests/test_plugins/test_loader.py
@@ -1,0 +1,142 @@
+"""
+Unit‑tests for the hybrid plugin loader.
+
+Covers:
+    • TOML discovery (valid / invalid)
+    • Entry‑point discovery
+    • Legacy register() plugins
+    • Duck‑typed Plugin classes
+    • Version mismatch handling
+"""
+
+from types import SimpleNamespace, ModuleType
+from unittest.mock import patch, MagicMock
+
+import textwrap
+
+import importlib
+import sys
+import tomllib
+import pytest
+
+from nuvom.plugins import loader
+
+
+# --------------------------------------------------------------------------- #
+#  Utility helpers
+# --------------------------------------------------------------------------- #
+def _tmp_toml(tmp_path, content: str):
+    file = tmp_path / ".nuvom_plugins.toml"
+    file.write_text(textwrap.dedent(content), encoding="utf-8")
+    return file
+
+
+# --------------------------------------------------------------------------- #
+#  TOML discovery
+# --------------------------------------------------------------------------- #
+def test_toml_targets_valid(tmp_path, monkeypatch):
+    toml = _tmp_toml(
+        tmp_path,
+        """
+        [plugins]
+        modules = ["foo.bar", "baz.plugin:MyPlugin"]
+        queue_backend  = ["my.queue:Q"]
+        result_backend = ["my.result:R"]
+        """,
+    )
+    monkeypatch.setattr(loader, "_TOML_PATH", toml)
+
+    assert sorted(loader._toml_targets()) == sorted(
+        ["foo.bar", "baz.plugin:MyPlugin", "my.queue:Q", "my.result:R"]
+    )
+
+
+def test_toml_targets_invalid(tmp_path, monkeypatch):
+    toml = _tmp_toml(tmp_path, "not = [valid")
+    monkeypatch.setattr(loader, "_TOML_PATH", toml)
+
+    assert loader._toml_targets() == []
+
+
+# --------------------------------------------------------------------------- #
+#  Entry‑point discovery
+# --------------------------------------------------------------------------- #
+def test_entry_point_targets(monkeypatch):
+    fake_ep = SimpleNamespace(value="mypkg.plugin:Plugin")
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points",
+        lambda group=None: [fake_ep] if group == "nuvom" else [],
+    )
+    assert loader._entry_point_targets() == ["mypkg.plugin:Plugin"]
+
+
+# --------------------------------------------------------------------------- #
+#  Legacy register() loading
+# --------------------------------------------------------------------------- #
+def test_load_plugin_register_function(monkeypatch):
+    def dummy_register():
+        dummy_register.called = True
+
+    dummy_register.called = False
+
+    # Make loader iterate a single spec
+    monkeypatch.setattr(loader, "_iter_targets", lambda: ["dummy.module"])
+    # Fresh state
+    loader._LOADED.clear()
+
+    # importlib.import_module returns the callable directly
+    monkeypatch.setattr("importlib.import_module", lambda _: dummy_register)
+
+    loader.load_plugins()
+    assert dummy_register.called
+    assert "dummy.module" in loader._LOADED
+
+
+# --------------------------------------------------------------------------- #
+#  Duck‑typed Plugin class loading
+# --------------------------------------------------------------------------- #
+class GoodPlugin:
+    api_version = "1.0"
+    name = "good"
+    provides = ["queue_backend"]
+    requires = []
+
+    def start(self, settings): ...
+    def stop(self): ...
+
+
+def test_load_plugin_class_success(monkeypatch):
+    monkeypatch.setattr(loader, "_iter_targets", lambda: ["plugin.good:GoodPlugin"])
+    loader._LOADED.clear()
+
+    fake_mod = ModuleType("plugin.good")
+    fake_mod.GoodPlugin = GoodPlugin
+    monkeypatch.setattr("importlib.import_module", lambda _: fake_mod)
+
+    loader.load_plugins()
+    assert "plugin.good:GoodPlugin" in loader._LOADED
+
+
+# --------------------------------------------------------------------------- #
+#  Version mismatch → should skip
+# --------------------------------------------------------------------------- #
+class BadVersionPlugin:
+    api_version = "99.99.0"
+    name = "bad"
+    provides = ["result_backend"]
+    requires = []
+
+    def start(self, settings): ...
+    def stop(self): ...
+
+
+def test_plugin_version_mismatch_skipped(monkeypatch):
+    monkeypatch.setattr(loader, "_iter_targets", lambda: ["plugin.bad:Bad"])
+    loader._LOADED.clear()
+
+    fake_mod = ModuleType("plugin.bad")
+    fake_mod.Bad = BadVersionPlugin
+    monkeypatch.setattr("importlib.import_module", lambda _: fake_mod)
+
+    loader.load_plugins()
+    assert "plugin.bad:Bad" not in loader._LOADED

--- a/tests/test_plugins/test_plugin_registry.py
+++ b/tests/test_plugins/test_plugin_registry.py
@@ -1,0 +1,100 @@
+# tests/plugins/test_registry.py
+"""
+Unit‑tests for the generic plugin `Registry` (nuvom.plugins.registry).
+
+The test‑suite focuses on:
+
+1. Basic registration / retrieval round‑trip
+2. Duplicate protection vs. `override=True`
+3. Resolution semantics when name is omitted
+4. Built‑in back‑compat shims (`register_queue_backend`, etc.)
+"""
+
+from types import SimpleNamespace
+import pytest
+
+from nuvom.plugins.registry import (
+    REGISTRY,
+    Registry,
+    register_queue_backend,
+    register_result_backend,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers / fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _fresh_registry(monkeypatch):
+    """
+    Patch the global `REGISTRY` with a brand‑new instance for each test so that
+    state from other tests (or the real runtime) cannot bleed in.
+    """
+    fresh = Registry()
+    monkeypatch.setattr("nuvom.plugins.registry.REGISTRY", fresh, raising=True)
+    yield fresh  # provide the patched instance to the test
+
+
+def _dummy(name):
+    """Return a unique dummy class for registration."""
+    return type(name, (), {})
+
+
+# --------------------------------------------------------------------------- #
+#  Test‑cases
+# --------------------------------------------------------------------------- #
+def test_basic_register_and_get(_fresh_registry: Registry):
+    cls = _dummy("MyQ")
+    _fresh_registry.register("queue_backend", "myq", cls)
+
+    resolved = _fresh_registry.get("queue_backend", "myq")
+    assert resolved is cls
+
+
+def test_duplicate_registration_raises(_fresh_registry: Registry):
+    cls1 = _dummy("One")
+    cls2 = _dummy("Two")
+
+    _fresh_registry.register("queue_backend", "dup", cls1)
+    with pytest.raises(ValueError):
+        _fresh_registry.register("queue_backend", "dup", cls2)
+
+
+def test_override_replaces_previous(_fresh_registry: Registry):
+    cls1 = _dummy("Old")
+    cls2 = _dummy("New")
+
+    _fresh_registry.register("result_backend", "swap", cls1)
+    _fresh_registry.register("result_backend", "swap", cls2, override=True)
+
+    assert _fresh_registry.get("result_backend", "swap") is cls2
+
+
+def test_get_without_name_single_provider(_fresh_registry: Registry):
+    cls = _dummy("Solo")
+    _fresh_registry.register("queue_backend", "solo", cls)
+
+    # Name omitted: should succeed because only one provider exists
+    assert _fresh_registry.get("queue_backend") is cls
+
+
+def test_get_without_name_multiple_providers_raises(_fresh_registry: Registry):
+    _fresh_registry.register("queue_backend", "a", _dummy("A"))
+    _fresh_registry.register("queue_backend", "b", _dummy("B"))
+
+    with pytest.raises(LookupError):
+        _fresh_registry.get("queue_backend")
+
+
+# --------------------------------------------------------------------------- #
+#  Legacy shim smoke‑test
+# --------------------------------------------------------------------------- #
+def test_legacy_shims_register_backend(_fresh_registry: Registry):
+    q_cls = _dummy("LegacyQ")
+    r_cls = _dummy("LegacyR")
+
+    register_queue_backend("legacyq", q_cls, override=True)
+    register_result_backend("legacyr", r_cls, override=True)
+
+    assert _fresh_registry.get("queue_backend", "legacyq") is q_cls
+    assert _fresh_registry.get("result_backend", "legacyr") is r_cls

--- a/tests/test_plugins/test_plugin_result_backend.py
+++ b/tests/test_plugins/test_plugin_result_backend.py
@@ -1,0 +1,76 @@
+# tests/test_plugins/test_plugin_result_backend.py
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+from nuvom import result_store
+from nuvom.config import get_settings
+from nuvom.result_store import reset_backend
+
+
+def test_plugin_result_backend(monkeypatch, tmp_path):
+    """
+    End‑to‑end check: a result backend registered by a *plugin* is selected
+    when `NUVOM_RESULT_BACKEND` points to it.
+    """
+    # ------------------------------------------------------------------ #
+    # 1.  Write a one‑file plugin with a DummyResultBackend
+    # ------------------------------------------------------------------ #
+    plugin_source = textwrap.dedent(
+        """
+        from nuvom.plugins.contracts import Plugin
+
+        class DummyResultBackend:
+            def set_result(self, *_, **__): pass
+            def get_result(self, job_id):      return {"dummy": True, "job_id": job_id}
+            def set_error (self, *_, **__): pass
+            def get_error(self, job_id):      return {"error": "Dummy", "job_id": job_id}
+
+        class HelloPlugin(Plugin):
+            api_version = "1.0"
+            name        = "hello_plugin"
+            provides    = ["result_backend"]
+
+            def start(self, _settings):       # register backend
+                from nuvom.plugins.registry import register_result_backend
+                register_result_backend("dummy", DummyResultBackend, override=True)
+
+            def stop(self):                   # no‑op teardown
+                pass
+        """
+    )
+    plugin_file = tmp_path / "hello_plugin.py"
+    plugin_file.write_text(plugin_source, encoding="utf‑8")
+
+    # Put tmp_path on import path so `import hello_plugin` works
+    sys.path.insert(0, str(tmp_path))
+
+    # ------------------------------------------------------------------ #
+    # 2.  Create .nuvom_plugins.toml that points to the new plugin
+    # ------------------------------------------------------------------ #
+    (tmp_path / ".nuvom_plugins.toml").write_text(
+        '[plugins]\nresult_backend = ["hello_plugin:HelloPlugin"]\n', encoding="utf‑8"
+    )
+
+    # ------------------------------------------------------------------ #
+    # 3.  Reconfigure Nuvom for this test
+    # ------------------------------------------------------------------ #
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NUVOM_RESULT_BACKEND", "dummy")
+
+    # Force the settings singleton to refresh so it picks up env‑var
+    get_settings(force_reload=True)
+
+    # Clear any previously‑cached backend
+    reset_backend()
+
+    # ------------------------------------------------------------------ #
+    # 4.  Exercise the store — should hit DummyResultBackend
+    # ------------------------------------------------------------------ #
+    result_store.set_result("abc", "func", result=123)
+    res = result_store.get_result("abc")
+
+    assert res["dummy"] is True
+    assert res["job_id"] == "abc"

--- a/tests/test_result_sqlite_backend.py
+++ b/tests/test_result_sqlite_backend.py
@@ -1,0 +1,100 @@
+# tests/test_result_sqlite_backend.py
+
+"""
+End-to-end tests for SQLiteResultBackend.
+
+These tests run against a temporary DB file so they are 100 % isolated.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from nuvom.result_backends.sqlite_backend import SQLiteResultBackend
+
+
+@pytest.fixture()
+def backend(tmp_path: Path):
+    """Return a fresh SQLite backend using a tmp file."""
+    db_file = tmp_path / "nuvom_test.db"
+    return SQLiteResultBackend(db_file)
+
+
+def _insert_success(backend: SQLiteResultBackend, job_id="job-success"):
+    backend.set_result(
+        job_id=job_id,
+        func_name="add",
+        result=42,
+        args=(40, 2),
+        kwargs={},
+        retries_left=0,
+        attempts=1,
+        created_at=time.time() - 1,
+        completed_at=time.time(),
+    )
+    return job_id
+
+
+def _insert_failure(backend: SQLiteResultBackend, job_id="job-fail"):
+    backend.set_error(
+        job_id=job_id,
+        func_name="explode",
+        error=ValueError("boom"),
+        args=(),
+        kwargs={},
+        retries_left=0,
+        attempts=1,
+        created_at=time.time() - 1,
+        completed_at=time.time(),
+    )
+    return job_id
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CRUD Tests
+# ──────────────────────────────────────────────────────────────────────────
+def test_set_and_get_result(backend):
+    jid = _insert_success(backend)
+    assert backend.get_result(jid) == 42
+    assert backend.get_error(jid) is None
+
+
+def test_set_and_get_error(backend):
+    jid = _insert_failure(backend)
+    err = backend.get_error(jid)
+    assert "boom" in err
+    assert backend.get_result(jid) is None
+
+
+def test_get_full_metadata_success(backend):
+    jid = _insert_success(backend)
+    meta = backend.get_full(jid)
+    assert meta["status"] == "SUCCESS"
+    assert meta["func_name"] == "add"
+    assert meta["result"] == 42
+    assert meta["error_msg"] is None
+
+
+def test_get_full_metadata_failure(backend):
+    jid = _insert_failure(backend)
+    meta = backend.get_full(jid)
+    assert meta["status"] == "FAILED"
+    assert meta["func_name"] == "explode"
+    assert "boom" in meta["error_msg"]
+
+
+def test_list_jobs_returns_ordered(backend):
+    s1 = _insert_success(backend, "A")
+    time.sleep(0.01)
+    f1 = _insert_failure(backend, "B")
+
+    jobs = backend.list_jobs()
+    # Most recent first
+    assert jobs[0]["job_id"] == f1
+    assert jobs[1]["job_id"] == s1
+
+    # Round-trip: ensure deserialized blobs are usable
+    assert jobs[1]["args"] == [40, 2]

--- a/tests/test_retry_delay.py
+++ b/tests/test_retry_delay.py
@@ -56,7 +56,7 @@ def test_job_is_retried_after_delay():
     worker.start(); dispatcher.start()
 
     time.sleep(0.5);  assert attempt_counter["count"] == 1  # first attempt
-    time.sleep(0.5);  assert attempt_counter["count"] == 1  # not yet retried
+    time.sleep(1);  assert attempt_counter["count"] == 1  # not yet retried
     time.sleep(1);  assert attempt_counter["count"] == 2  # retried & ok
 
     assert get_result(job.id) == "recovered"


### PR DESCRIPTION
<html>
<body>
<h3>🚀 Nuvom v0.9: Plugin System, Graceful Shutdown, and SQLite Backend</h3>
<p>This release delivers <strong>all three flagship features for v0.9</strong>, focused on <strong>extensibility, reliability, and backend versatility</strong>.</p>
<hr>
<h3>✨ Major Features</h3>
<h4>🧩 Plugin Architecture (TOML + EntryPoint)</h4>
<ul>
<li>
<p>Adds a flexible plugin loading system with support for:</p>
<ul>
<li>
<p><code inline="">.nuvom_plugins.toml</code> registration</p>
</li>
<li>
<p>Python package <code inline="">entry_points</code> (<code inline="">[project.entry-points.nuvom]</code>)</p>
</li>
<li>
<p>Legacy <code inline="">register()</code> fallback (with deprecation warning)</p>
</li>
</ul>
</li>
<li>
<p>Enforces the <code inline="">Plugin</code> protocol:</p>
<ul>
<li>
<p><code inline="">start(settings: dict)</code></p>
</li>
<li>
<p><code inline="">stop()</code></p>
</li>
<li>
<p><code inline="">name</code>, <code inline="">provides</code>, <code inline="">requires</code>, <code inline="">api_version</code></p>
</li>
</ul>
</li>
<li>
<p>Runtime plugin validation, api_version compatibility checks</p>
</li>
<li>
<p>Fully testable via <code inline="">nuvom plugin test</code></p>
</li>
</ul>
<h4>💾 SQLite Result Backend</h4>
<ul>
<li>
<p>New built-in backend using <code inline="">sqlite3</code>, stores results + errors persistently</p>
</li>
<li>
<p>Compatible with <code inline="">set_result()</code>, <code inline="">get_result()</code>, <code inline="">set_error()</code>, <code inline="">get_error()</code></p>
</li>
<li>
<p>Configurable via <code inline="">NUVOM_RESULT_BACKEND=sqlite</code> and <code inline="">NUVOM_SQLITE_DB_PATH</code></p>
</li>
<li>
<p>Can be loaded as a plugin (<code inline="">provides = ["result_backend"]</code>)</p>
</li>
</ul>
<h4>🔁 Graceful Worker Lifecycle</h4>
<ul>
<li>
<p>Workers now call <code inline="">plugin.stop()</code> on shutdown</p>
</li>
<li>
<p>Plugins can safely release resources or close connections</p>
</li>
<li>
<p>Extends to future observability or metrics plugins</p>
</li>
</ul>
<hr>
<h3>🧪 Testing Improvements</h3>
<ul>
<li>
<p>Plugin-aware tests for both queue and result backends</p>
</li>
<li>
<p>Test support for <code inline="">.nuvom_plugins.toml</code> overrides</p>
</li>
<li>
<p>Temporary plugin injection into test suite</p>
</li>
</ul>
<hr>
<h3>🧠 Developer UX</h3>
<ul>
<li>
<p>New CLI commands:</p>
<ul>
<li>
<p><code inline="">nuvom plugin status</code></p>
</li>
<li>
<p><code inline="">nuvom plugin scaffold</code></p>
</li>
<li>
<p><code inline="">nuvom plugin test</code></p>
</li>
</ul>
</li>
<li>
<p>Built-in type checking + metadata validation</p>
</li>
<li>
<p>Plugin registry debug info printed on error</p>
</li>
</ul>
<hr>
<h3>🧹 Deprecations</h3>
<ul>
<li>
<p>Legacy <code inline="">register()</code> plugin pattern is now deprecated and will be removed in v1.0</p>
</li>
</ul>

</body>
</html>