### PR TITLE
fix: Added tomllib compatibility with tomli for Python < 3.11

### DIFF
--- a/nuvom/plugins/loader.py
+++ b/nuvom/plugins/loader.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata as md
-import tomllib
 import warnings
 from pathlib import Path
 from types import ModuleType
@@ -28,6 +27,7 @@ import threading
 from nuvom.log import get_logger
 from nuvom.plugins.contracts import API_VERSION, Plugin
 from nuvom.plugins.registry import REGISTRY
+from nuvom.utils.compat_utils.tomllib_compat import tomllib
 
 # --------------------------------------------------------------------------- #
 # Globals

--- a/nuvom/utils/compat_utils/tomllib_compat.py
+++ b/nuvom/utils/compat_utils/tomllib_compat.py
@@ -1,0 +1,20 @@
+"""
+Compatibility module for safely importing tomllib for different Python versions.
+
+This module provides unified `tomllib` import that works for Python 3.10 and later.
+For Python < 3.11, it will falls back to the `tomli` library, which must be installed.
+
+Usage:
+    from nuvom.utils.compat_utils.tomllib_compat import tomllib
+"""
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "Failed to import tomllib. For Python < 3.11, please install `tomli` "
+            "run `pip install tomli.`"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "pydantic>=2.0.0",
   "typer>=0.7.0,<0.12.0",
   "python-dotenv>=1.1.0",
-  "msgpack>=1.1.0"
+  "msgpack>=1.1.0",
+  "tomli; python_version < '3.11'"
 ]
 
 [build-system]

--- a/tests/test_plugins/test_plugins.py
+++ b/tests/test_plugins/test_plugins.py
@@ -12,13 +12,13 @@ import importlib
 import sys
 from types import ModuleType
 from pathlib import Path
-import tomllib
 import textwrap
 
 import pytest
 
 from nuvom.plugins import registry as plugreg
 from nuvom.plugins import loader as plugload
+from nuvom.utils.compat_utils.tomllib_compat import tomllib
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+"""
+Tests for utils
+"""
+
+def test_tomllib_import():
+    from nuvom.utils.compat_utils.tomllib_compat import tomllib
+    assert hasattr(tomllib, 'load')
+    assert callable(tomllib.load)


### PR DESCRIPTION
Fixes #78 by adding compatibility for tomllib in Python < 3.11 using tomli as a fallback.
- Adds tomli as a conditional dependency for Python < 3.11.
- Updates all `import tomllib` to `from nuvom.utils.compat_utils.tomllib_compat import tomllib`.
- Tested on Python 3.10 and 3.11.
